### PR TITLE
Integrate CuraEngine slicing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,10 +148,16 @@ target_include_directories(_CuraEngine INTERFACE
 # ────────────────────────────────────────────────────────────────────────────────
 # 16) Optional meshlib availability define (if your code tests MESHLIB_AVAILABLE)
 target_compile_definitions(RendRipper PRIVATE
-		PYTHON_EXECUTABLE=\"${CMAKE_CURRENT_SOURCE_DIR}/3DModelGenerator/TripoSR/.venv/Scripts/python.exe\"
-		GENERATE_MODEL_SCRIPT=\"${CMAKE_CURRENT_SOURCE_DIR}/3DModelGenerator/TripoSR/run.py\"
-		OUTPUT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/generated_models\"
-		MESHLIB_AVAILABLE
+                PYTHON_EXECUTABLE=\"${CMAKE_CURRENT_SOURCE_DIR}/3DModelGenerator/TripoSR/.venv/Scripts/python.exe\"
+                GENERATE_MODEL_SCRIPT=\"${CMAKE_CURRENT_SOURCE_DIR}/3DModelGenerator/TripoSR/run.py\"
+                OUTPUT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/generated_models\"
+                CURA_ENGINE_EXE=\"${CMAKE_CURRENT_SOURCE_DIR}/Slicer/CuraEngine/build/Release/CuraEngine.exe\"
+                FDMPRINTER_DEF=\"${CMAKE_CURRENT_SOURCE_DIR}/Slicer/CuraEngine/build/Release/fdmprinter.def.json\"
+                BAMBULAB_BASE_DEF=\"${CMAKE_CURRENT_SOURCE_DIR}/Slicer/CuraEngine/build/Release/bambulab_base.def.json\"
+                BAMBULAB_A1MINI_DEF=\"${CMAKE_CURRENT_SOURCE_DIR}/Slicer/CuraEngine/build/Release/bambulab_a1mini.def.json\"
+                DRAGON_SETTINGS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/Slicer/CuraEngine/build/Release/dragon_settings.json\"
+                MODEL_SETTINGS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/Slicer/CuraEngine/build/Release/model_settings.json\"
+                MESHLIB_AVAILABLE
 )
 
 # ────────────────────────────────────────────────────────────────────────────────

--- a/src/Application.h
+++ b/src/Application.h
@@ -83,6 +83,8 @@ private:
     bool showErrorModal_ = false;
     std::string errorModalMessage_;
     std::vector<glm::vec3> loadedMeshDimensions_;
+    std::vector<std::string> modelFilePaths_;
+    bool loadModelAfterGeneration_ = true;
     // Camera: Z-up orbital
     void cameraView(glm::mat4 &view, glm::vec3 &cameraWorldPosition) const;
 
@@ -94,6 +96,7 @@ private:
 
     void loadModel( std::string&  modelPath );
     void loadImageFor3DModel(std::string&  imagePath);
+    void sliceActiveModel();
 
     // Interaction
     void getActiveModel(glm::mat4 &viewMatrix, const ImVec2& viewportScreenPos, const ImVec2& viewportSize);


### PR DESCRIPTION
## Summary
- integrate CuraEngine execution via new `sliceActiveModel()`
- allow launching slicing from the File menu
- manage progress popup for slicing
- store processed model file paths
- expose CuraEngine and printer definitions to the build

## Testing
- `cmake -S . -B build` *(fails: CMake 3.30 required)*

------
https://chatgpt.com/codex/tasks/task_e_684345c010408321a60ef71f796869c6