### PR TITLE
Refactor SceneRenderer and model loading

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1,0 +1,49 @@
+#include "FrameBuffer.h"
+#include <iostream>
+
+FrameBuffer::~FrameBuffer()
+{
+    if (fbo_) glDeleteFramebuffers(1, &fbo_);
+    if (colorTex_) glDeleteTextures(1, &colorTex_);
+    if (depthStencilRBO_) glDeleteRenderbuffers(1, &depthStencilRBO_);
+}
+
+void FrameBuffer::Init(int width, int height)
+{
+    glGenFramebuffers(1, &fbo_);
+    glGenTextures(1, &colorTex_);
+    glGenRenderbuffers(1, &depthStencilRBO_);
+    Resize(width, height);
+}
+
+void FrameBuffer::Resize(int width, int height)
+{
+    if (!fbo_) Init(width, height); // ensure created
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+    glBindTexture(GL_TEXTURE_2D, colorTex_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex_, 0);
+
+    glBindRenderbuffer(GL_RENDERBUFFER, depthStencilRBO_);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthStencilRBO_);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        std::cerr << "Framebuffer not complete!" << std::endl;
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void FrameBuffer::Bind()
+{
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+}
+
+void FrameBuffer::Unbind()
+{
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <glad/glad.h>
+
+class FrameBuffer {
+public:
+    FrameBuffer() = default;
+    ~FrameBuffer();
+
+    void Init(int width, int height);
+    void Resize(int width, int height);
+    void Bind();
+    void Unbind();
+
+    GLuint GetColorTexture() const { return colorTex_; }
+
+private:
+    GLuint fbo_ = 0;
+    GLuint colorTex_ = 0;
+    GLuint depthStencilRBO_ = 0;
+};

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -3,9 +3,7 @@
 #include "glad/glad.h"
 #include "ObjConverter.h"
 #include "TextureLoader.h"
-#include <assimp/Importer.hpp>
-#include <assimp/Exporter.hpp>
-#include <assimp/postprocess.h>
+#include "ModelLoader.h"
 #include <stdexcept>
 #include <algorithm>
 #include <iostream>
@@ -16,7 +14,8 @@ Model::Model( std::string& path) {
     std::cout<< "Loading model from: " << path << std::endl;
     std::string outPath = directory + "/temp.stl";
     ObjConverter::Convert(path, outPath);
-    loadModel(path);
+    ModelLoader loader;
+    meshes = loader.Load(path);
     computeBounds();
 
 }
@@ -50,55 +49,6 @@ void Model::Draw(const Shader& shader) const {
 
 
 
-void Model::loadModel(const std::string& path) {
-    Assimp::Importer importer;
-    const aiScene* scene = importer.ReadFile(path,
-                                             aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_GenSmoothNormals);
-    if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode)
-        throw std::runtime_error(importer.GetErrorString());
-    processNode(scene->mRootNode, scene);
-}
-
-void Model::processNode(aiNode* node, const aiScene* scene) {
-    for (unsigned i = 0; i < node->mNumMeshes; ++i) {
-        aiMesh* mesh = scene->mMeshes[node->mMeshes[i]];
-        meshes.emplace_back(processMesh(mesh, scene));
-    }
-    for (unsigned i = 0; i < node->mNumChildren; ++i)
-        processNode(node->mChildren[i], scene);
-}
-
-Mesh Model::processMesh(aiMesh* mesh, const aiScene* scene) {
-    std::vector<Vertex> vertices;
-    std::vector<unsigned> indices;
-    std::vector<Texture> textures;
-
-    for (unsigned i = 0; i < mesh->mNumVertices; ++i) {
-        Vertex v;
-        v.pos  = { mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z };
-        v.norm = mesh->HasNormals()
-                 ? glm::vec3(mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z)
-                 : glm::vec3(0.0f);
-        v.uv   = mesh->mTextureCoords[0]
-                 ? glm::vec2(mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y)
-                 : glm::vec2(0.0f);
-        vertices.push_back(v);
-    }
-    for (unsigned i = 0; i < mesh->mNumFaces; ++i)
-        for (unsigned j = 0; j < mesh->mFaces[i].mNumIndices; ++j)
-            indices.push_back(mesh->mFaces[i].mIndices[j]);
-
-    if (mesh->mMaterialIndex >= 0) {
-        aiMaterial* mat = scene->mMaterials[mesh->mMaterialIndex];
-        TextureLoader loader;
-        auto diffuse  = loader.LoadMaterialTextures(mat, aiTextureType_DIFFUSE,  "texture_diffuse", directory);
-        auto specular = loader.LoadMaterialTextures(mat, aiTextureType_SPECULAR, "texture_specular", directory);
-        textures.insert(textures.end(), diffuse.begin(), diffuse.end());
-        textures.insert(textures.end(), specular.begin(), specular.end());
-    }
-
-    return {std::move(vertices), std::move(indices), std::move(textures)};
-}
 
 
 void Model::computeBounds() {

--- a/src/Model.h
+++ b/src/Model.h
@@ -4,6 +4,7 @@
 #include <glm/glm.hpp>
 #include <assimp/scene.h>
 #include "Mesh.h"
+#include "ModelLoader.h"
 enum class Axis { X_UP, Y_UP, Z_UP };
 class Model {
 public:
@@ -36,7 +37,4 @@ private:
     std::string directory;
     std::vector<Mesh> meshes;
 
-    void loadModel(const std::string& path);
-    void processNode(aiNode* node, const aiScene* scene);
-    Mesh processMesh(aiMesh* mesh, const aiScene* scene);
 };

--- a/src/ModelLoader.cpp
+++ b/src/ModelLoader.cpp
@@ -1,0 +1,62 @@
+#include "ModelLoader.h"
+#include "TextureLoader.h"
+#include <assimp/Importer.hpp>
+#include <assimp/postprocess.h>
+#include <stdexcept>
+
+std::vector<Mesh> ModelLoader::Load(const std::string& path) const
+{
+    std::vector<Mesh> meshes;
+    Assimp::Importer importer;
+    const aiScene* scene = importer.ReadFile(path,
+        aiProcess_Triangulate | aiProcess_FlipUVs | aiProcess_GenSmoothNormals);
+    if (!scene || scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE || !scene->mRootNode)
+        throw std::runtime_error(importer.GetErrorString());
+    std::string directory = path.substr(0, path.find_last_of("/\\"));
+    processNode(scene->mRootNode, scene, directory, meshes);
+    return meshes;
+}
+
+void ModelLoader::processNode(aiNode* node, const aiScene* scene, const std::string& directory, std::vector<Mesh>& meshes) const
+{
+    for (unsigned i = 0; i < node->mNumMeshes; ++i) {
+        aiMesh* mesh = scene->mMeshes[node->mMeshes[i]];
+        meshes.emplace_back(processMesh(mesh, scene, directory));
+    }
+    for (unsigned i = 0; i < node->mNumChildren; ++i)
+        processNode(node->mChildren[i], scene, directory, meshes);
+}
+
+Mesh ModelLoader::processMesh(aiMesh* mesh, const aiScene* scene, const std::string& directory) const
+{
+    std::vector<Vertex> vertices;
+    std::vector<unsigned> indices;
+    std::vector<Texture> textures;
+
+    for (unsigned i = 0; i < mesh->mNumVertices; ++i) {
+        Vertex v;
+        v.pos = { mesh->mVertices[i].x, mesh->mVertices[i].y, mesh->mVertices[i].z };
+        v.norm = mesh->HasNormals()
+            ? glm::vec3(mesh->mNormals[i].x, mesh->mNormals[i].y, mesh->mNormals[i].z)
+            : glm::vec3(0.0f);
+        v.uv = mesh->mTextureCoords[0]
+            ? glm::vec2(mesh->mTextureCoords[0][i].x, mesh->mTextureCoords[0][i].y)
+            : glm::vec2(0.0f);
+        vertices.push_back(v);
+    }
+
+    for (unsigned i = 0; i < mesh->mNumFaces; ++i)
+        for (unsigned j = 0; j < mesh->mFaces[i].mNumIndices; ++j)
+            indices.push_back(mesh->mFaces[i].mIndices[j]);
+
+    if (mesh->mMaterialIndex >= 0) {
+        aiMaterial* mat = scene->mMaterials[mesh->mMaterialIndex];
+        TextureLoader loader;
+        auto diffuse = loader.LoadMaterialTextures(mat, aiTextureType_DIFFUSE, "texture_diffuse", directory);
+        auto specular = loader.LoadMaterialTextures(mat, aiTextureType_SPECULAR, "texture_specular", directory);
+        textures.insert(textures.end(), diffuse.begin(), diffuse.end());
+        textures.insert(textures.end(), specular.begin(), specular.end());
+    }
+
+    return { std::move(vertices), std::move(indices), std::move(textures) };
+}

--- a/src/ModelLoader.h
+++ b/src/ModelLoader.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <assimp/scene.h>
+#include "Mesh.h"
+
+class ModelLoader {
+public:
+    std::vector<Mesh> Load(const std::string& path) const;
+
+private:
+    void processNode(aiNode* node, const aiScene* scene, const std::string& directory, std::vector<Mesh>& meshes) const;
+    Mesh processMesh(aiMesh* mesh, const aiScene* scene, const std::string& directory) const;
+};

--- a/src/SceneRenderer.h
+++ b/src/SceneRenderer.h
@@ -6,6 +6,7 @@
 #include "GridRenderer.h"
 #include "VolumeBoxRenderer.h"
 #include "AxesRenderer.h"
+#include "FrameBuffer.h"
 using json = nlohmann::json;
 
 class Shader;
@@ -24,7 +25,7 @@ public:
     void RenderGCodeUpToLayer(int maxLayerIndex);
     void SetViewportSize(int width, int height);
 
-    GLuint GetSceneTexture() const { return colorTex_; }
+    GLuint GetSceneTexture() const { return framebuffer_.GetColorTexture(); }
     const glm::mat4 &GetViewMatrix() const { return viewMatrix_; }
     const glm::mat4 &GetProjectionMatrix() const { return projectionMatrix_; }
     void SetGridColor(const glm::vec3 &color) { gridColor_ = color; }
@@ -38,18 +39,14 @@ public:
 
 private:
     void InitializeDefaultTexture();
-    void InitializeFBO();
     void InitializeGrid();
     void InitializeVolumeBox();
     void InitializeAxes();
-    void ResizeFBOIfNeeded(int width, int height);
     void RenderGridAndVolume();
     void RenderAxes();
 
-    GLuint fbo_ = 0;
-    GLuint colorTex_ = 0;
-    GLuint rboDepthStencil_ = 0;
-    GLuint defaultWhiteTex_ = 0;
+    FrameBuffer framebuffer_;
+    GLuint     defaultWhiteTex_ = 0;
 
     glm::vec3 gridColor_ = glm::vec3(0.4f, 0.4f, 0.45f);
     int viewportWidth_ = 1;


### PR DESCRIPTION
## Summary
- introduce a reusable `FrameBuffer` utility
- introduce a `ModelLoader` that owns Assimp interactions
- refactor `SceneRenderer` to delegate FBO management to `FrameBuffer`
- simplify `Model` by delegating loading work to `ModelLoader`

## Testing
- `cmake -B build` *(fails: CMake 3.30 required)*

------
https://chatgpt.com/codex/tasks/task_e_68437e1e0a248321a09e29f8c47ba850