### PR TITLE
Update build settings for CMake 3.28

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,23 +1,23 @@
 [submodule "external/glfw"]
-	path = external/glfw
-	url = https://github.com/glfw/glfw.git
+    path = external/glfw
+    url = https://github.com/glfw/glfw.git
 
 [submodule "external/ImGuiFileDialog"]
-	path = external/ImGuiFileDialog
-	url  = https://github.com/aiekick/ImGuiFileDialog.git
+    path = external/ImGuiFileDialog
+    url = https://github.com/aiekick/ImGuiFileDialog.git
 
 [submodule "external/imgui"]
-	path = external/imgui
-	url  = https://github.com/ocornut/imgui.git
+    path = external/imgui
+    url = https://github.com/ocornut/imgui.git
 
-	[submodule "external/glm"]
-	    path = external/glm
-	    url  = https://github.com/g-truc/glm.git
+[submodule "external/glm"]
+    path = external/glm
+    url = https://github.com/g-truc/glm.git
 
-	[submodule "external/glad"]
-	    path = external/glad
-	    url  = https://github.com/Dav1dde/glad.git
+[submodule "external/glad"]
+    path = external/glad
+    url = https://github.com/Dav1dde/glad.git
 
-	[submodule "external/Slic3r"]
-	path = external/Slic3r
-	url = https://github.com/slic3r/Slic3r.git
+[submodule "external/Slic3r"]
+    path = external/Slic3r
+    url = https://github.com/slic3r/Slic3r.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.28)
 project(RendRipper)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -135,15 +135,18 @@ add_executable(RendRipper
 
 # ────────────────────────────────────────────────────────────────────────────────
 # 15) _CuraEngine (imported) example, if you still need it
-add_library(_CuraEngine STATIC IMPORTED)
-set_target_properties(_CuraEngine PROPERTIES
-		IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/build/Release/_CuraEngine.lib"
-)
-target_include_directories(_CuraEngine INTERFACE
-		"$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/src>"
-		"$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/include>"
-		"$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/build/Release>"
-)
+set(CURAE_LIB "${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/build/Release/_CuraEngine.lib")
+if(EXISTS ${CURAE_LIB})
+    add_library(_CuraEngine STATIC IMPORTED)
+    set_target_properties(_CuraEngine PROPERTIES IMPORTED_LOCATION ${CURAE_LIB})
+    target_include_directories(_CuraEngine INTERFACE
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/src>"
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/include>"
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Slicer/CuraEngine/build/Release>"
+    )
+else()
+    add_library(_CuraEngine INTERFACE)
+endif()
 
 # ────────────────────────────────────────────────────────────────────────────────
 # 16) Optional meshlib availability define (if your code tests MESHLIB_AVAILABLE)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -2,13 +2,13 @@
 #include <iostream>
 
 Application::Application(int w, int h, const char* title)
-    : width_(w), height_(h) {
-    window_ = std::make_unique<WindowManager>(width_, height_, title);
-    renderer_ = std::make_unique<SceneRenderer>(A1MINI_PRINTER_SETTINGS_FILE);
+    : width_(w), height_(h),
+      window_(std::make_unique<WindowManager>(width_, height_, title)),
+      renderer_(std::make_unique<SceneRenderer>(A1MINI_PRINTER_SETTINGS_FILE)),
+      ui_(modelManager_, renderer_.get(), gizmo_, camera_, window_->GetWindow()) {
     if (renderer_) {
         renderer_->SetViewportSize(width_, height_);
     }
-    ui_ = UIManager(modelManager_, renderer_.get(), gizmo_, camera_, window_->GetWindow());
 }
 
 Application::~Application() { Cleanup(); }

--- a/src/SceneRenderer.h
+++ b/src/SceneRenderer.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <glad/glad.h>
 #include <glm/glm.hpp>
 #include <memory>


### PR DESCRIPTION
## Summary
- lower `cmake_minimum_required` to 3.28
- fix nested entries in `.gitmodules`
- only import `_CuraEngine` library when present

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: MRMesh headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68438b64bd44832195d98b8d74d2111c