### PR TITLE
Fix OpenGL header conflict on Windows

### DIFF
--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -1,3 +1,10 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <commdlg.h>
+#include <GLFW/glfw3native.h>
+#endif
+
 #include "UIManager.h"
 #include "MeshRepairer.h"
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
## Summary
- include Windows system headers before Glad in `UIManager.cpp`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_684391ccc8488321a88577b0ea6ab621