### PR TITLE
Fix OpenGL header inclusion order

### DIFF
--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -1,5 +1,6 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#include <glad/glad.h> // glad must be included before Windows headers
 #include <windows.h>
 #include <commdlg.h>
 #include <GLFW/glfw3native.h>

--- a/src/UIManager.h
+++ b/src/UIManager.h
@@ -6,6 +6,9 @@
 #include <filesystem>
 #include <imgui.h>
 #include <ImGuizmo.h>
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 #include "ModelManager.h"
 #include "SceneRenderer.h"

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <glad/glad.h>
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 #include <imgui.h>
 #include <imgui_impl_glfw.h>


### PR DESCRIPTION
## Summary
- include `glad` before any Windows headers on Windows
- avoid GLFW bringing in system OpenGL headers by defining `GLFW_INCLUDE_NONE`

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)` *(fails: MRMesh/MRMesh.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684394bac3008321bc5ab5dd3d39d7de