### PR TITLE
Fix OpenGL header inclusion order

### DIFF
--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -1,11 +1,17 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#include <glad/glad.h> // glad must be included before Windows headers
 #include <windows.h>
 #include <commdlg.h>
-#include <GLFW/glfw3native.h>
 #endif
 
 #include "UIManager.h"
+#ifdef _WIN32
+#ifndef GLFW_EXPOSE_NATIVE_WIN32
+#define GLFW_EXPOSE_NATIVE_WIN32
+#endif
+#include <GLFW/glfw3native.h>
+#endif
 #include "MeshRepairer.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
@@ -13,6 +19,18 @@
 #include <limits>
 #include <thread>
 #include <cstdio>
+
+// Utility: ray-sphere intersection using GLM helpers
+static bool RayIntersectSphere(const glm::vec3& origin,
+                               const glm::vec3& dir,
+                               const glm::vec3& center,
+                               float radius,
+                               float& t)
+{
+    // GLM requires the squared radius and a normalized direction
+    return glm::intersectRaySphere(origin, glm::normalize(dir),
+                                   center, radius * radius, t);
+}
 
 UIManager::UIManager(ModelManager& mm, SceneRenderer* renderer,
                      GizmoController& gizmo, CameraController& camera,

--- a/src/UIManager.h
+++ b/src/UIManager.h
@@ -6,6 +6,9 @@
 #include <filesystem>
 #include <imgui.h>
 #include <ImGuizmo.h>
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 #include "ModelManager.h"
 #include "SceneRenderer.h"

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <glad/glad.h>
+#ifndef GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_NONE
+#endif
 #include <GLFW/glfw3.h>
 #include <imgui.h>
 #include <imgui_impl_glfw.h>


### PR DESCRIPTION
## Summary
- include glad before Windows headers
- load GLFW's Win32 APIs after including `glfw3.h`
- implement `RayIntersectSphere` helper around GLM

## Testing
- `cmake ..` *(fails: external/glfw and ImGuiFileDialog missing)*

------
https://chatgpt.com/codex/tasks/task_e_684394bac3008321bc5ab5dd3d39d7de