### PR TITLE
Use transformed model for slicing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,8 @@ target_compile_definitions(RendRipper PRIVATE
 				MODEL_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/model_settings/model_settings.json\"
 		        PRIMITIVE_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/fdmprinter.def.json\"
 		        BASE_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_base.def.json\"
-		        A1MINI_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini.def.json\"
+                        A1MINI_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini.def.json\"
+                        GCODE_OUTPUT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/generated_gcode\"
                 MESHLIB_AVAILABLE
 )
 

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -14,6 +14,8 @@ public:
     int LoadModel(const std::string &modelPath);
     void UnloadModel(int index);
 
+    void ExportTransformedModel(int index, const std::string &outPath) const;
+
     size_t Count() const { return models_.size(); }
     Model* GetModel(int index) { return index>=0 && index<(int)models_.size()? models_[index].get():nullptr; }
     Shader* GetShader(int index) { return index>=0 && index<(int)shaders_.size()? shaders_[index].get():nullptr; }


### PR DESCRIPTION
## Summary
- define a path for generated g-code
- allow exporting a transformed model to STL
- slice using the exported STL
- clean up temporary files after slicing
- keep an empty directory for generated g-code

## Testing
- `cmake -S . -B build` *(fails: source directories for dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68440494f84c8321b8572d7ea41194fb