### PR TITLE
Fix gcode loading after slicing

### DIFF
--- a/src/UIManager.h
+++ b/src/UIManager.h
@@ -32,6 +32,7 @@ private:
     void loadImageFor3DModel(std::string& imagePath);
     void sliceActiveModel();
     void UnloadModel(int idx);
+    void finalizeSlicing();
     void showGenerationModal();
     void showSlicingModal();
     void showErrorModal(std::string &message);
@@ -66,4 +67,11 @@ private:
     bool showErrorModal_ = false;
     std::string errorModalMessage_;
     GLFWwindow* window_ = nullptr;
+
+    // Slicing bookkeeping
+    std::string pendingGcodePath_;
+    std::string pendingResizedPath_;
+    std::string pendingStlPath_;
+    int slicingModelIndex_ = -1;
+    std::atomic<bool> loadGcodePending_{false};
 };


### PR DESCRIPTION
## Summary
- fix loading and unloading logic for slicer results
- load gcode on the main thread once slicing finishes

## Testing
- `cmake ..` *(fails: missing glfw and ImGuiFileDialog sources)*
- `g++ -std=c++17 -fsyntax-only src/UIManager.cpp` *(fails: missing imgui headers)*

------
https://chatgpt.com/codex/tasks/task_e_68442594b5448321bfbc8fe1518ad06c