### PR TITLE
Optimize GCode model memory usage

### DIFF
--- a/src/GCodeModel.h
+++ b/src/GCodeModel.h
@@ -27,7 +27,7 @@ public:
     void DrawUpToLayer(int maxLayerIndex, Shader& lineShader) const;
 
     /// Number of layers parsed
-    int GetLayerCount() const { return static_cast<int>(layers_.size()); }
+    int GetLayerCount() const { return static_cast<int>(layerVertexCounts_.size()); }
 
     /// Returns the Z-height (in mm) of each layer index.
     /// That is, layerZs_[i] = the Z coordinate that was first encountered for layer i.
@@ -50,6 +50,7 @@ private:
     // Each layer is now a flat list of ColoredVertex pairs forming line segments
     // layers_[i] = vertices for layer i, in consecutive pairs.
     std::vector<std::vector<ColoredVertex>> layers_;
+    std::vector<size_t> layerVertexCounts_;
     std::vector<float> layerZs_;
 
     // OpenGL handles: each layer gets its own VAO/VBO pair.


### PR DESCRIPTION
## Summary
- store per-layer vertex counts in `GCodeModel`
- release CPU memory after uploading data to the GPU
- update draw calls to use the stored counts

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844293e0cd8832189329047ae57e204