### PR TITLE
Fix gcode display position

### DIFF
--- a/src/SceneRenderer.cpp
+++ b/src/SceneRenderer.cpp
@@ -142,6 +142,7 @@ void SceneRenderer::RenderGCodeLayer(int layerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
+    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f));
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);
@@ -153,6 +154,7 @@ void SceneRenderer::RenderGCodeUpToLayer(int maxLayerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
+    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f));
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);


### PR DESCRIPTION
## Summary
- offset gcode rendering so that sliced files appear centered on the printer bed

## Testing
- `cmake ..` *(fails: external libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_684431f888b08321937a4a858ef0ab4e