### PR TITLE
Fix support settings and gcode alignment

### DIFF
--- a/resources/model_settings/model_settings.json
+++ b/resources/model_settings/model_settings.json
@@ -1,5 +1,5 @@
 {
-    "settings": {
+    "overrides": {
         "roofing_layer_count": {
             "value": 1,
             "default_value": 1

--- a/src/SceneRenderer.cpp
+++ b/src/SceneRenderer.cpp
@@ -142,7 +142,7 @@ void SceneRenderer::RenderGCodeLayer(int layerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
-    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f));
+    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f) + gcodeOffset_);
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);
@@ -154,7 +154,7 @@ void SceneRenderer::RenderGCodeUpToLayer(int maxLayerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
-    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f));
+    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f) + gcodeOffset_);
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);

--- a/src/SceneRenderer.h
+++ b/src/SceneRenderer.h
@@ -36,6 +36,7 @@ public:
     float GetPrintHeight() const { return volumeHeight_; }
 
     void SetGCodeModel(std::shared_ptr<GCodeModel> gcodeModel) { gcodeModel_ = gcodeModel; }
+    void SetGCodeOffset(const glm::vec3& offset) { gcodeOffset_ = offset; }
     int currentGCodeLayerIndex_ = -1;
 
 private:
@@ -63,6 +64,8 @@ private:
 
     std::shared_ptr<GCodeModel> gcodeModel_;
     std::unique_ptr<Shader> gcodeShader_;
+
+    glm::vec3 gcodeOffset_ = glm::vec3(0.0f);
 
     GridRenderer     gridRenderer_;
     VolumeBoxRenderer volumeBoxRenderer_;


### PR DESCRIPTION
## Summary
- use `overrides` key in `model_settings.json`
- add gcode offset handling to `SceneRenderer`
- preserve gcode position when loading/slicing

## Testing
- `python3 -m json.tool resources/model_settings/model_settings.json`

------
https://chatgpt.com/codex/tasks/task_e_6844391320c88321b4621793f23a42c9