### PR TITLE
Add dynamic slicing settings menu

### DIFF
--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -17,13 +17,17 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <filesystem>
 #include <iostream>
+#include <functional>
 #include <limits>
 #include <thread>
 #include <regex>
 #include <cstdio>
+#include <cstring>
 #include <nlohmann/json.hpp>
 
 #include "glm/gtx/intersect.hpp"
+
+using json = nlohmann::json;
 
 // Utility: ray-sphere intersection using GLM helpers
 static bool RayIntersectSphere(const glm::vec3& origin,
@@ -40,7 +44,10 @@ static bool RayIntersectSphere(const glm::vec3& origin,
 UIManager::UIManager(ModelManager& mm, SceneRenderer* renderer,
                      GizmoController& gizmo, CameraController& camera,
                      GLFWwindow* window)
-    : modelManager_(mm), renderer_(renderer), gizmo_(gizmo), camera_(camera), window_(window) {}
+    : modelManager_(mm), renderer_(renderer), gizmo_(gizmo), camera_(camera), window_(window)
+{
+    loadModelSettings();
+}
 
 void UIManager::Frame() {
     ImGuizmo::BeginFrame();
@@ -547,6 +554,58 @@ void UIManager::openModelPropertiesDialog() {
     } else {
         ImGui::Text("No model selected.");
     }
+
+    ImGui::Separator();
+    if (ImGui::CollapsingHeader("Slicing Settings")) {
+        if (!modelSettingsLoaded_) {
+            ImGui::Text("model_settings.json not loaded");
+        } else {
+            bool msChanged = false;
+            auto& overrides = modelSettings_["overrides"];
+            for (auto it = overrides.begin(); it != overrides.end(); ++it) {
+                auto& entry = it.value();
+                if (!entry.contains("value")) continue;
+                const std::string key = it.key();
+                auto& val = entry["value"];
+                ImGui::PushID(key.c_str());
+                if (val.is_boolean()) {
+                    bool b = val.get<bool>();
+                    if (ImGui::Checkbox(key.c_str(), &b)) { val = b; msChanged = true; }
+                } else if (val.is_number_integer()) {
+                    int v = val.get<int>();
+                    if (ImGui::InputInt(key.c_str(), &v)) { val = v; msChanged = true; }
+                } else if (val.is_number_float()) {
+                    double v = val.get<double>();
+                    if (ImGui::InputDouble(key.c_str(), &v)) { val = v; msChanged = true; }
+                } else if (val.is_string()) {
+                    std::string s = val.get<std::string>();
+                    auto optIt = enumOptions_.find(key);
+                    if (optIt != enumOptions_.end() && !optIt->second.empty()) {
+                        int current = 0;
+                        for (size_t i=0;i<optIt->second.size();++i)
+                            if (optIt->second[i] == s) current = static_cast<int>(i);
+                        if (ImGui::BeginCombo("", optIt->second[current].c_str())) {
+                            for (size_t i=0;i<optIt->second.size();++i) {
+                                bool selected = (current==static_cast<int>(i));
+                                if (ImGui::Selectable(optIt->second[i].c_str(), selected)) {
+                                    current = static_cast<int>(i); msChanged = true; s = optIt->second[i];
+                                }
+                                if (selected) ImGui::SetItemDefaultFocus();
+                            }
+                            ImGui::EndCombo();
+                        }
+                    } else {
+                        char buf[128];
+                        strncpy(buf, s.c_str(), sizeof(buf)); buf[sizeof(buf)-1] = '\0';
+                        if (ImGui::InputText("", buf, sizeof(buf))) { s = buf; msChanged = true; }
+                    }
+                    val = s;
+                }
+                ImGui::PopID();
+            }
+            if (msChanged) saveModelSettings();
+        }
+    }
     if (gcodeModel_) {
         int layerCount = gcodeModel_->GetLayerCount();
         auto layerHeights = gcodeModel_->GetLayerHeights();
@@ -633,6 +692,49 @@ void UIManager::finalizeSlicing() {
     } catch (const std::exception &e) {
         std::lock_guard lk(slicingMessageMutex_);
         slicingMessage_ += std::string(" | Load failed: ") + e.what();
+    }
+}
+
+void UIManager::loadModelSettings() {
+    try {
+        std::ifstream in(MODEL_SETTINGS_FILE);
+        if (in.is_open()) {
+            in >> modelSettings_;
+            modelSettingsLoaded_ = true;
+        }
+        // Load enum options from primitive printer settings for dropdowns
+        std::ifstream printerIn(PRIMITIVE_PRINTER_SETTINGS_FILE);
+        if (printerIn.is_open()) {
+            json pj; printerIn >> pj;
+            if (pj.contains("settings")) {
+                std::function<void(const json&)> recur = [&](const json& node){
+                    for (auto it = node.begin(); it != node.end(); ++it) {
+                        if (!it->is_object()) continue;
+                        const json& obj = *it;
+                        if (obj.contains("type") && obj["type"] == "enum" && obj.contains("options")) {
+                            std::vector<std::string> opts;
+                            for (auto& op : obj["options"].items()) opts.push_back(op.key());
+                            enumOptions_[it.key()] = opts;
+                        }
+                        if (obj.contains("children")) recur(obj["children"]);
+                    }
+                };
+                recur(pj["settings"]);
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to load model settings: " << e.what() << std::endl;
+        modelSettingsLoaded_ = false;
+    }
+}
+
+void UIManager::saveModelSettings() {
+    if (!modelSettingsLoaded_) return;
+    try {
+        std::ofstream out(MODEL_SETTINGS_FILE);
+        out << modelSettings_.dump(4);
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to save model settings: " << e.what() << std::endl;
     }
 }
 

--- a/src/UIManager.h
+++ b/src/UIManager.h
@@ -4,6 +4,8 @@
 #include <mutex>
 #include <string>
 #include <filesystem>
+#include <vector>
+#include <unordered_map>
 #include <imgui.h>
 #include <ImGuizmo.h>
 #ifndef GLFW_INCLUDE_NONE
@@ -15,6 +17,9 @@
 #include "GizmoController.h"
 #include "CameraController.h"
 #include "GCodeModel.h"
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
 
 class UIManager {
 public:
@@ -28,6 +33,8 @@ private:
     void openFileDialog(const std::function<void(std::string&)>& onFileSelected = nullptr);
     void openRenderScene();
     void openModelPropertiesDialog();
+    void loadModelSettings();
+    void saveModelSettings();
     void loadModel(std::string& modelPath);
     void loadImageFor3DModel(std::string& imagePath);
     void sliceActiveModel();
@@ -74,4 +81,8 @@ private:
     std::string pendingStlPath_;
     int slicingModelIndex_ = -1;
     std::atomic<bool> loadGcodePending_{false};
+
+    json modelSettings_;
+    bool modelSettingsLoaded_ = false;
+    std::unordered_map<std::string, std::vector<std::string>> enumOptions_;
 };


### PR DESCRIPTION
## Summary
- load model settings from JSON at startup
- populate dropdown values from printer definition enums
- show new "Slicing Settings" section in Model Properties
- save updated overrides back to `model_settings.json`

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_68444f0e108c8321a0d57ef24cf0ba5a