### PR TITLE
Improve slice placement checks and bed info

### DIFF
--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -23,6 +23,12 @@ public:
     glm::vec3 GetDimensions(int index) const { return meshDimensions_[index]; }
     const std::string &GetPath(int index) const { return modelPaths_[index]; }
 
+    /// Return the world-space center of the model after transform
+    glm::vec3 GetWorldCenter(int index) const;
+
+    /// Check if the model fits within the given half-width/half-depth bed
+    bool FitsInBed(int index, float bedHalfX, float bedHalfY) const;
+
     void EnforceGridConstraint(int index);
     void UpdateDimensions(int index);
 


### PR DESCRIPTION
## Summary
- compute world-space model center and whether model fits within printer bed
- show model center on bed in UI properties panel
- store correct center coordinates when slicing models
- check gcode bounds before loading and show error when it exceeds printer volume

## Testing
- `cmake -S . -B build` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_6844cce5e7d4832185ba0a109491ce49