### PR TITLE
Improve coordinate consistency and slicing validation

### DIFF
--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -5,6 +5,8 @@
 #include <assimp/scene.h>
 #include <memory>
 #include <stdexcept>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtx/quaternion.hpp>
 
 #include "MeshRepairer.h"
 
@@ -99,13 +101,18 @@ void ModelManager::UpdateDimensions(int index) {
     meshDimensions_[index] = base * sc;
 }
 
-void ModelManager::ExportTransformedModel(int index, const std::string &outPath) const {
+void ModelManager::ExportTransformedModel(int index, const std::string &outPath,
+                                          bool includeTranslation) const {
     if (index < 0 || index >= static_cast<int>(models_.size())) return;
 
     const Model &model = *models_[index];
     const Transform &tf = *transforms_[index];
 
-    glm::mat4 mat = tf.getMatrix();
+    glm::mat4 mat(1.0f);
+    if (includeTranslation)
+        mat = glm::translate(mat, tf.translation);
+    mat *= glm::toMat4(tf.rotationQuat);
+    mat = glm::scale(mat, tf.scale);
     glm::mat3 normalMat = glm::transpose(glm::inverse(glm::mat3(mat)));
 
     auto scene = std::make_unique<aiScene>();
@@ -157,4 +164,37 @@ void ModelManager::ExportTransformedModel(int index, const std::string &outPath)
     if (ret != aiReturn_SUCCESS) {
         throw std::runtime_error(std::string("Assimp export error: ") + exporter.GetErrorString());
     }
+}
+
+glm::vec3 ModelManager::GetWorldCenter(int index) const {
+    if (index < 0 || index >= static_cast<int>(models_.size())) return glm::vec3(0.0f);
+    const Model* mdl = models_[index].get();
+    const Transform* tf = transforms_[index].get();
+    if (!mdl || !tf) return glm::vec3(0.0f);
+    glm::vec4 wc = tf->getMatrix() * glm::vec4(mdl->center, 1.0f);
+    return glm::vec3(wc);
+}
+
+bool ModelManager::FitsInBed(int index, float bedHalfX, float bedHalfY) const {
+    if (index < 0 || index >= static_cast<int>(models_.size())) return false;
+    const Model* mdl = models_[index].get();
+    const Transform* tf = transforms_[index].get();
+    if (!mdl || !tf) return false;
+    glm::mat4 mat = tf->getMatrix();
+    glm::vec3 corners[8] = {
+        {mdl->minBounds.x, mdl->minBounds.y, mdl->minBounds.z},
+        {mdl->maxBounds.x, mdl->minBounds.y, mdl->minBounds.z},
+        {mdl->minBounds.x, mdl->maxBounds.y, mdl->minBounds.z},
+        {mdl->maxBounds.x, mdl->maxBounds.y, mdl->minBounds.z},
+        {mdl->minBounds.x, mdl->minBounds.y, mdl->maxBounds.z},
+        {mdl->maxBounds.x, mdl->minBounds.y, mdl->maxBounds.z},
+        {mdl->minBounds.x, mdl->maxBounds.y, mdl->maxBounds.z},
+        {mdl->maxBounds.x, mdl->maxBounds.y, mdl->maxBounds.z}
+    };
+    for (auto &c : corners) {
+        glm::vec3 wc = glm::vec3(mat * glm::vec4(c, 1.0f));
+        if (wc.x < -bedHalfX || wc.x > bedHalfX || wc.y < -bedHalfY || wc.y > bedHalfY)
+            return false;
+    }
+    return true;
 }

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -14,7 +14,12 @@ public:
     int LoadModel(const std::string &modelPath);
     void UnloadModel(int index);
 
-    void ExportTransformedModel(int index, const std::string &outPath) const;
+    /// Export the model with its current transform applied.
+    /// If includeTranslation is false, the translation component is ignored so
+    /// the mesh is exported around the origin. This is useful when the slicer
+    /// will position the part via mesh_position_x/y.
+    void ExportTransformedModel(int index, const std::string &outPath,
+                               bool includeTranslation = true) const;
 
     size_t Count() const { return models_.size(); }
     Model* GetModel(int index) { return index>=0 && index<(int)models_.size()? models_[index].get():nullptr; }
@@ -22,6 +27,12 @@ public:
     Transform* GetTransform(int index) { return index>=0 && index<(int)transforms_.size()? transforms_[index].get():nullptr; }
     glm::vec3 GetDimensions(int index) const { return meshDimensions_[index]; }
     const std::string &GetPath(int index) const { return modelPaths_[index]; }
+
+    /// Return the world-space center of the model after transform
+    glm::vec3 GetWorldCenter(int index) const;
+
+    /// Check if the model fits within the given half-width/half-depth bed
+    bool FitsInBed(int index, float bedHalfX, float bedHalfY) const;
 
     void EnforceGridConstraint(int index);
     void UpdateDimensions(int index);

--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -364,6 +364,14 @@ void UIManager::sliceActiveModel() {
     if (activeModel_ < 0 || activeModel_ >= static_cast<int>(modelManager_.Count()))
         return;
 
+    float hx = renderer_ ? renderer_->GetBedHalfWidth() : 0.f;
+    float hy = renderer_ ? renderer_->GetBedHalfDepth() : 0.f;
+    if (!modelManager_.FitsInBed(activeModel_, hx, hy)) {
+        errorModalMessage_ = "Model exceeds printer volume.";
+        showErrorModal_ = true;
+        return;
+    }
+
     slicingModelIndex_ = activeModel_;
     pendingStlPath_ = modelManager_.GetPath(activeModel_);
     std::filesystem::path base(pendingStlPath_);
@@ -383,7 +391,8 @@ void UIManager::sliceActiveModel() {
             std::lock_guard lk(slicingMessageMutex_);
             slicingMessage_ = "model_settings.json not found.";
         }
-        modelManager_.ExportTransformedModel(slicingModelIndex_, pendingResizedPath_);
+        // Export mesh without translation so we can position via mesh_position overrides
+        modelManager_.ExportTransformedModel(slicingModelIndex_, pendingResizedPath_, false);
         float offX = renderer_ ? renderer_->GetBedHalfWidth()  : 0.f;
         float offY = renderer_ ? renderer_->GetBedHalfDepth() : 0.f;
 
@@ -503,8 +512,14 @@ void UIManager::openModelPropertiesDialog() {
         ImGui::Text("Model Index: %d", activeModel_);
         glm::vec3 dims = modelManager_.GetDimensions(activeModel_);
         ImGui::Text("Real Dimensions (mm): %.2f x %.2f x %.2f", dims.x, dims.y, dims.z);
-        ImGui::Separator();
         auto& tf = *modelManager_.GetTransform(activeModel_);
+        glm::vec3 wc = modelManager_.GetWorldCenter(activeModel_);
+        float hx = renderer_ ? renderer_->GetBedHalfWidth() : 0.f;
+        float hy = renderer_ ? renderer_->GetBedHalfDepth() : 0.f;
+        ImGui::Text("Center on Bed (mm): X=%.2f Y=%.2f", wc.x + hx, wc.y + hy);
+        ImGui::Text("Gizmo Position (mm): X=%.2f Y=%.2f", tf.translation.x + hx,
+                    tf.translation.y + hy);
+        ImGui::Separator();
         bool changed = false;
         if (ImGui::BeginTable("TransformTable", 4, ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings)) {
             ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 100.0f);
@@ -514,8 +529,12 @@ void UIManager::openModelPropertiesDialog() {
             ImGui::TableHeadersRow();
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Translation");
-            ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN); if (ImGui::DragFloat("##TransX", &tf.translation.x, 0.01f)) changed = true;
-            ImGui::TableSetColumnIndex(2); ImGui::SetNextItemWidth(-FLT_MIN); if (ImGui::DragFloat("##TransY", &tf.translation.y, 0.01f)) changed = true;
+            float transX = tf.translation.x + hx;
+            float transY = tf.translation.y + hy;
+            ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+            if (ImGui::DragFloat("##TransX", &transX, 0.01f)) { tf.translation.x = transX - hx; changed = true; }
+            ImGui::TableSetColumnIndex(2); ImGui::SetNextItemWidth(-FLT_MIN);
+            if (ImGui::DragFloat("##TransY", &transY, 0.01f)) { tf.translation.y = transY - hy; changed = true; }
             ImGui::TableSetColumnIndex(3); ImGui::SetNextItemWidth(-FLT_MIN); if (ImGui::DragFloat("##TransZ", &tf.translation.z, 0.01f)) changed = true;
             glm::vec3 euler = tf.getEulerAngles();
             ImGui::TableNextRow(); ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Rotation");
@@ -703,15 +722,7 @@ void UIManager::finalizeSlicing() {
     try {
         auto gm = std::make_shared<GCodeModel>(pendingGcodePath_);
         if (renderer_) {
-            glm::vec3 gcodeCenter = gm->GetCenter() -
-                glm::vec3(renderer_->GetBedHalfWidth(), renderer_->GetBedHalfDepth(), 0.f);
-            glm::vec3 modelCenter(0.f);
-            if (slicingModelIndex_ >= 0) {
-                Transform* tf = modelManager_.GetTransform(slicingModelIndex_);
-                if (tf) modelCenter = tf->translation;
-            }
-            glm::vec3 offset = modelCenter - gcodeCenter;
-            renderer_->SetGCodeOffset(offset);
+            renderer_->SetGCodeOffset(glm::vec3(0.0f));
             renderer_->SetGCodeModel(gm);
         }
         gcodeModel_ = gm;


### PR DESCRIPTION
## Summary
- edit translation coordinates in bed-relative space
- validate model fits bed before slicing
- remove inaccurate G-code bounds check and zero gcode offset

## Testing
- `cmake -S . -B build` *(fails: Could not find nlohmann_json package)*

------
https://chatgpt.com/codex/tasks/task_e_6844cce5e7d4832185ba0a109491ce49