### PR TITLE
Display mass center and preserve gcode placement

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -176,3 +176,16 @@ std::vector<glm::vec3> Model::getAllPositions() const {
     }
     return out;
 }
+
+glm::vec3 Model::computeMassCenter() const {
+    glm::vec3 sum(0.0f);
+    size_t count = 0;
+    for (const auto& mesh : meshes) {
+        for (const auto& v : mesh.getVertices()) {
+            sum += v.pos;
+            ++count;
+        }
+    }
+    if (count == 0) return glm::vec3(0.0f);
+    return sum / static_cast<float>(count);
+}

--- a/src/Model.h
+++ b/src/Model.h
@@ -27,6 +27,8 @@ public:
     Axis determineUpAxis() const;
 
     std::vector<glm::vec3> getAllPositions() const;
+    /// Compute an approximate mass center by averaging all vertex positions
+    glm::vec3 computeMassCenter() const;
 
 
     const std::vector<Mesh>& getMeshes() const noexcept { return meshes; }


### PR DESCRIPTION
## Summary
- compute model mass center
- show mass center XY coordinates in the properties window
- remove G90/G91 injection and rely on slicer output

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845530b6b488321bb8a674beb56b3d2