### PR TITLE
Adjust default slicing settings

### DIFF
--- a/resources/model_settings/model_settings.json
+++ b/resources/model_settings/model_settings.json
@@ -80,6 +80,46 @@
         "infill_support_enabled": {
             "value": false,
             "default_value": false
+        },
+        "layer_height": {
+            "value": 0.1,
+            "default_value": 0.1
+        },
+        "material_print_temperature": {
+            "value": 220,
+            "default_value": 220
+        },
+        "material_bed_temperature": {
+            "value": 60,
+            "default_value": 60
+        },
+        "support_type": {
+            "value": "buildplate",
+            "default_value": "buildplate"
+        },
+        "adhesion_type": {
+            "value": "skirt",
+            "default_value": "skirt"
+        },
+        "speed_print": {
+            "value": 30,
+            "default_value": 30
+        },
+        "speed_travel": {
+            "value": 60,
+            "default_value": 60
+        },
+        "retraction_enable": {
+            "value": true,
+            "default_value": true
+        },
+        "retraction_amount": {
+            "value": 6.5,
+            "default_value": 6.5
+        },
+        "retraction_speed": {
+            "value": 25,
+            "default_value": 25
         }
     }
 }

--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -735,8 +735,24 @@ void UIManager::renderModels(glm::mat4&) {
 void UIManager::finalizeSlicing() {
     try {
         auto gm = std::make_shared<GCodeModel>(pendingGcodePath_);
+        glm::vec3 offset(0.f);
+        if (modelSettingsLoaded_) {
+            try {
+                auto& ov = modelSettings_["overrides"];
+                if (ov.contains("mesh_position_x") && ov.contains("mesh_position_y")) {
+                    double posX = ov["mesh_position_x"]["value"].get<double>();
+                    double posY = ov["mesh_position_y"]["value"].get<double>();
+                    glm::vec3 c = gm->GetCenter();
+                    offset = glm::vec3(static_cast<float>(posX - c.x),
+                                       static_cast<float>(posY - c.y),
+                                       0.f);
+                }
+            } catch (const std::exception& e) {
+                std::cerr << "Offset compute failed: " << e.what() << std::endl;
+            }
+        }
         if (renderer_) {
-            renderer_->SetGCodeOffset(glm::vec3(0.f));
+            renderer_->SetGCodeOffset(offset);
             renderer_->SetGCodeModel(gm);
         }
         gcodeModel_ = gm;


### PR DESCRIPTION
## Summary
- adjust default slicing settings using values from `resources/Dragon.gcode`
- offset rendered G-code using mesh position

## Testing
- `cmake -B build -S .` *(fails: The source directory `external/glfw` does not contain a `CMakeLists.txt` file)*

------
https://chatgpt.com/codex/tasks/task_e_684576e63f0883219fc06d4282ecd820