### PR TITLE
Implement adjustable print bed origin

### DIFF
--- a/src/rendering/GridRenderer.cpp
+++ b/src/rendering/GridRenderer.cpp
@@ -30,7 +30,8 @@ void GridRenderer::Init(float halfX, float halfY)
                                       "../../resources/shaders/infinite_grid.frag");
 }
 
-void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj)
+void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj,
+                          const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     glEnable(GL_BLEND);
@@ -39,7 +40,8 @@ void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj)
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    glm::mat4 model = glm::translate(glm::mat4(1.0f), offset);
+    shader_->setMat4("model", model);
     if (shader_->hasUniform("gridSpacing")) shader_->setFloat("gridSpacing", 5.0f);
     if (shader_->hasUniform("lineWidth")) shader_->setFloat("lineWidth", 0.5f);
     glBindVertexArray(vao_);

--- a/src/rendering/GridRenderer.h
+++ b/src/rendering/GridRenderer.h
@@ -10,7 +10,8 @@ public:
     ~GridRenderer();
 
     void Init(float halfX, float halfY);
-    void Render(const glm::mat4 &view, const glm::mat4 &proj);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj,
+                const glm::vec3 &offset = glm::vec3(0.0f));
 
 private:
     GLuint vao_ = 0, vbo_ = 0, ebo_ = 0;

--- a/src/rendering/SceneRenderer.cpp
+++ b/src/rendering/SceneRenderer.cpp
@@ -127,14 +127,15 @@ void SceneRenderer::RenderModel(const Model &model, Shader &shader, const Transf
 
 void SceneRenderer::RenderGridAndVolume()
 {
-    gridRenderer_.Render(viewMatrix_, projectionMatrix_);
-    volumeBoxRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_);
+    gridRenderer_.Render(viewMatrix_, projectionMatrix_, bedOrigin_);
+    volumeBoxRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_, bedOrigin_);
     RenderAxes();
 }
 
 void SceneRenderer::RenderAxes()
 {
-    axesRenderer_.Render(viewMatrix_, projectionMatrix_, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.f));
+    axesRenderer_.Render(viewMatrix_, projectionMatrix_,
+                         glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.f) + bedOrigin_);
 }
 
 void SceneRenderer::RenderGCodeLayer(int layerIndex)

--- a/src/rendering/SceneRenderer.h
+++ b/src/rendering/SceneRenderer.h
@@ -35,6 +35,9 @@ public:
     float GetBedHalfDepth() const { return volumeHalfY_; }
     float GetPrintHeight() const { return volumeHeight_; }
 
+    void SetBedOrigin(const glm::vec3 &origin) { bedOrigin_ = origin; }
+    const glm::vec3 &GetBedOrigin() const { return bedOrigin_; }
+
     void SetGCodeModel(std::shared_ptr<GCodeModel> gcodeModel) { gcodeModel_ = gcodeModel; }
     void SetGCodeOffset(const glm::vec3& offset) { gcodeOffset_ = offset; }
     int currentGCodeLayerIndex_ = -1;
@@ -66,6 +69,7 @@ private:
     std::unique_ptr<Shader> gcodeShader_;
 
     glm::vec3 gcodeOffset_ = glm::vec3(0.0f);
+    glm::vec3 bedOrigin_  = glm::vec3(0.0f);
 
     GridRenderer     gridRenderer_;
     VolumeBoxRenderer volumeBoxRenderer_;

--- a/src/rendering/VolumeBoxRenderer.cpp
+++ b/src/rendering/VolumeBoxRenderer.cpp
@@ -27,13 +27,16 @@ void VolumeBoxRenderer::Init(float halfX, float halfY, float height)
                                        "../../resources/shaders/simple_line.frag");
 }
 
-void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color)
+void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj,
+                               const glm::vec3 &color,
+                               const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    glm::mat4 model = glm::translate(glm::mat4(1.0f), offset);
+    shader_->setMat4("model", model);
     if (shader_->hasUniform("lineColor")) shader_->setVec3("lineColor", color);
     glBindVertexArray(vao_);
     glDrawArrays(GL_LINES, 0, 24);

--- a/src/rendering/VolumeBoxRenderer.h
+++ b/src/rendering/VolumeBoxRenderer.h
@@ -10,7 +10,9 @@ public:
     ~VolumeBoxRenderer();
 
     void Init(float halfX, float halfY, float height);
-    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj,
+                const glm::vec3 &color,
+                const glm::vec3 &offset = glm::vec3(0.0f));
 
 private:
     GLuint vao_ = 0, vbo_ = 0;

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -732,6 +732,11 @@ void UIManager::finalizeSlicing() {
                     offset = glm::vec3(static_cast<float>(posX - c.x),
                                        static_cast<float>(posY - c.y),
                                        0.f);
+                    if (renderer_) {
+                        float worldX = static_cast<float>(posX - renderer_->GetBedHalfWidth());
+                        float worldY = static_cast<float>(posY - renderer_->GetBedHalfDepth());
+                        renderer_->SetBedOrigin(glm::vec3(worldX, worldY, 0.f));
+                    }
                 }
             } catch (const std::exception& e) {
                 std::cerr << "Offset compute failed: " << e.what() << std::endl;


### PR DESCRIPTION
## Summary
- allow adjusting the print bed origin
- pass an offset to GridRenderer and VolumeBoxRenderer
- expose `SetBedOrigin` on `SceneRenderer`
- set bed origin when loading sliced G-code

## Testing
- `cmake -B build` *(fails: Could not find nlohmann_jsonConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6845b90a636c83218000cb622acce9d4