### PR TITLE
Fix platform orientation for BambuLab A1 mini

### DIFF
--- a/src/rendering/AxesRenderer.cpp
+++ b/src/rendering/AxesRenderer.cpp
@@ -30,7 +30,7 @@ void AxesRenderer::Init()
                                        "../../resources/shaders/simple_colored_line.frag");
 }
 
-void AxesRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &offset)
+void AxesRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::mat4 &model, const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     GLboolean depthTestEnabled;
@@ -40,8 +40,8 @@ void AxesRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const gl
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     shader_->use();
-    glm::mat4 model = glm::translate(glm::mat4(1.0f), offset);
-    shader_->setMat4("model", model);
+    glm::mat4 m = glm::translate(model, offset);
+    shader_->setMat4("model", m);
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
     glBindVertexArray(vao_);

--- a/src/rendering/AxesRenderer.h
+++ b/src/rendering/AxesRenderer.h
@@ -10,7 +10,7 @@ public:
     ~AxesRenderer();
 
     void Init();
-    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &offset);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::mat4 &model, const glm::vec3 &offset);
 
 private:
     GLuint vao_ = 0, vbo_ = 0;

--- a/src/rendering/GridRenderer.cpp
+++ b/src/rendering/GridRenderer.cpp
@@ -30,7 +30,7 @@ void GridRenderer::Init(float halfX, float halfY)
                                       "../../resources/shaders/infinite_grid.frag");
 }
 
-void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj)
+void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::mat4 &model)
 {
     if (!shader_ || vao_ == 0) return;
     glEnable(GL_BLEND);
@@ -39,7 +39,7 @@ void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj)
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    shader_->setMat4("model", model);
     if (shader_->hasUniform("gridSpacing")) shader_->setFloat("gridSpacing", 5.0f);
     if (shader_->hasUniform("lineWidth")) shader_->setFloat("lineWidth", 0.5f);
     glBindVertexArray(vao_);

--- a/src/rendering/GridRenderer.h
+++ b/src/rendering/GridRenderer.h
@@ -10,7 +10,7 @@ public:
     ~GridRenderer();
 
     void Init(float halfX, float halfY);
-    void Render(const glm::mat4 &view, const glm::mat4 &proj);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::mat4 &model);
 
 private:
     GLuint vao_ = 0, vbo_ = 0, ebo_ = 0;

--- a/src/rendering/SceneRenderer.h
+++ b/src/rendering/SceneRenderer.h
@@ -62,6 +62,8 @@ private:
     float volumeHalfY_;
     float volumeHeight_;
 
+    glm::mat4 platformTransform_ = glm::mat4(1.0f);
+
     std::shared_ptr<GCodeModel> gcodeModel_;
     std::unique_ptr<Shader> gcodeShader_;
 

--- a/src/rendering/VolumeBoxRenderer.cpp
+++ b/src/rendering/VolumeBoxRenderer.cpp
@@ -27,13 +27,13 @@ void VolumeBoxRenderer::Init(float halfX, float halfY, float height)
                                        "../../resources/shaders/simple_line.frag");
 }
 
-void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color)
+void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::mat4 &model, const glm::vec3 &color)
 {
     if (!shader_ || vao_ == 0) return;
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    shader_->setMat4("model", model);
     if (shader_->hasUniform("lineColor")) shader_->setVec3("lineColor", color);
     glBindVertexArray(vao_);
     glDrawArrays(GL_LINES, 0, 24);

--- a/src/rendering/VolumeBoxRenderer.h
+++ b/src/rendering/VolumeBoxRenderer.h
@@ -10,7 +10,7 @@ public:
     ~VolumeBoxRenderer();
 
     void Init(float halfX, float halfY, float height);
-    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::mat4 &model, const glm::vec3 &color);
 
 private:
     GLuint vao_ = 0, vbo_ = 0;


### PR DESCRIPTION
## Summary
- parse `platform_offset` from printer definition and store transform
- pass build plate transform when rendering grid, volume box and axes
- orient gcode using the same transform
- update renderer interfaces for model matrix

## Testing
- `cmake -S . -B build` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4f03ab083219cd12ee991380d42