### PR TITLE
Fix gcode offset when loading files

### DIFF
--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -114,7 +114,11 @@ void UIManager::showMenuBar() {
                     try {
                         gcodeModel_ = std::make_shared<GCodeModel>(selected);
                         if (renderer_) {
-                            renderer_->SetGCodeOffset(glm::vec3(0.f));
+                            glm::vec3 c = gcodeModel_->GetCenter();
+                            glm::vec3 offset(renderer_->GetBedHalfWidth() - c.x,
+                                             renderer_->GetBedHalfDepth() - c.y,
+                                             0.f);
+                            renderer_->SetGCodeOffset(offset);
                             renderer_->SetGCodeModel(gcodeModel_);
                         }
                         currentGCodeLayer_ = -1;


### PR DESCRIPTION
## Summary
- ensure opened gcode is centered on the build plate

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*


------
https://chatgpt.com/codex/tasks/task_e_6845e3d04b848321b14bfbd6ed2e13cf