### PR TITLE
Implement texture caching and shared resources

### DIFF
--- a/src/models/Mesh.cpp
+++ b/src/models/Mesh.cpp
@@ -1,7 +1,7 @@
 #include "Mesh.h"
 #include <glad/glad.h>
 
-Mesh::Mesh(std::vector<Vertex> v, std::vector<unsigned> i, std::vector<Texture> t)
+Mesh::Mesh(std::vector<Vertex> v, std::vector<unsigned> i, std::vector<std::shared_ptr<Texture>> t)
         : vertices(std::move(v)), indices(std::move(i)), textures(std::move(t)),
           VAO(0), VBO(0), EBO(0)
 {
@@ -14,8 +14,6 @@ Mesh::~Mesh() {
     if (VBO) glDeleteBuffers(1, &VBO);
     if (EBO) glDeleteBuffers(1, &EBO);
 
-    for (auto& tex : textures)
-        if (tex.id) glDeleteTextures(1, &tex.id);
 }
 
 Mesh::Mesh(Mesh&& o) noexcept
@@ -31,8 +29,7 @@ Mesh& Mesh::operator=(Mesh&& o) noexcept {
         if (VAO) glDeleteVertexArrays(1, &VAO);
         if (VBO) glDeleteBuffers(1, &VBO);
         if (EBO) glDeleteBuffers(1, &EBO);
-        for (auto& tex : textures)
-            if (tex.id) glDeleteTextures(1, &tex.id);
+
 
         vertices = std::move(o.vertices);
         indices  = std::move(o.indices);
@@ -73,12 +70,12 @@ void Mesh::Draw(const Shader& shader) const {
     for (unsigned i = 0; i < textures.size(); ++i) {
         glActiveTexture(GL_TEXTURE0 + i);
         std::string number;
-        if (textures[i].type == "texture_diffuse")
+        if (textures[i]->type == "texture_diffuse")
             number = std::to_string(diffuseNr++);
         else
             number = std::to_string(specularNr++);
-        shader.setInt(textures[i].type + number, i);
-        glBindTexture(GL_TEXTURE_2D, textures[i].id);
+        shader.setInt(textures[i]->type + number, i);
+        glBindTexture(GL_TEXTURE_2D, textures[i]->id);
     }
     glActiveTexture(GL_TEXTURE0);
     glBindVertexArray(VAO);

--- a/src/models/Mesh.h
+++ b/src/models/Mesh.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <memory>
 #include "Shader.h"
 
 struct Vertex {
@@ -10,14 +11,15 @@ struct Vertex {
 };
 
 struct Texture {
-    unsigned int id;
+    unsigned int id = 0;
     std::string type;
     std::string path;
+    ~Texture();
 };
 
 class Mesh {
 public:
-    Mesh(std::vector<Vertex> verts, std::vector<unsigned> idxs, std::vector<Texture> texs);
+    Mesh(std::vector<Vertex> verts, std::vector<unsigned> idxs, std::vector<std::shared_ptr<Texture>> texs);
     ~Mesh();
 
     Mesh(const Mesh&) = delete;
@@ -35,6 +37,6 @@ private:
 
     std::vector<Vertex>  vertices;
     std::vector<unsigned> indices;
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
     unsigned int VAO, VBO, EBO;
 };

--- a/src/models/ModelLoader.cpp
+++ b/src/models/ModelLoader.cpp
@@ -1,5 +1,6 @@
 #include "ModelLoader.h"
 #include "TextureLoader.h"
+#include <memory>
 #include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
 #include <stdexcept>
@@ -31,7 +32,7 @@ Mesh ModelLoader::processMesh(aiMesh* mesh, const aiScene* scene, const std::str
 {
     std::vector<Vertex> vertices;
     std::vector<unsigned> indices;
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
     for (unsigned i = 0; i < mesh->mNumVertices; ++i) {
         Vertex v;

--- a/src/models/ModelLoader.h
+++ b/src/models/ModelLoader.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <assimp/scene.h>
+#include <memory>
 #include "Mesh.h"
 
 class ModelLoader {

--- a/src/models/ModelManager.cpp
+++ b/src/models/ModelManager.cpp
@@ -11,6 +11,7 @@
 
 
 #include "MeshRepairer.h"
+#include "ShaderCache.h"
 
 int ModelManager::LoadModel(const std::string &modelPath) {
     std::string directory = modelPath.substr(0, modelPath.find_last_of("/\\"));
@@ -52,8 +53,9 @@ int ModelManager::LoadModel(const std::string &modelPath) {
     t->scale = glm::vec3(scaleFactor);
     t->rotationQuat = glm::quat(1,0,0,0);
     transforms_.push_back(std::move(t));
-    shaders_.emplace_back(std::make_unique<Shader>("../../resources/shaders/model_shader.vert",
-                                                  "../../resources/shaders/model_shader.frag"));
+    shaders_.emplace_back(
+        ShaderCache::Get("../../resources/shaders/model_shader.vert",
+                        "../../resources/shaders/model_shader.frag"));
     models_.emplace_back(std::move(mPtr));
     int idx = static_cast<int>(models_.size()) - 1;
     EnforceGridConstraint(idx);

--- a/src/models/ModelManager.h
+++ b/src/models/ModelManager.h
@@ -30,7 +30,7 @@ public:
     void UpdateDimensions(int index);
 
 private:
-    std::vector<std::unique_ptr<Shader>> shaders_;
+    std::vector<std::shared_ptr<Shader>> shaders_;
     std::vector<std::unique_ptr<Model>> models_;
     std::vector<std::unique_ptr<Transform>> transforms_;
     std::vector<glm::vec3> meshDimensions_;

--- a/src/models/Texture.cpp
+++ b/src/models/Texture.cpp
@@ -1,0 +1,9 @@
+#include "Mesh.h"
+#include <glad/glad.h>
+
+Texture::~Texture(){
+    if(id){
+        glDeleteTextures(1, &id);
+        id = 0;
+    }
+}

--- a/src/rendering/ShaderCache.cpp
+++ b/src/rendering/ShaderCache.cpp
@@ -1,0 +1,31 @@
+#include "ShaderCache.h"
+#include <sstream>
+
+std::unordered_map<std::string, std::weak_ptr<Shader>> ShaderCache::cache_;
+
+static std::string makeKey(const std::string& v, const std::string& f, const std::string& g){
+    std::ostringstream oss;
+    oss << v << '|' << f << '|' << g;
+    return oss.str();
+}
+
+std::shared_ptr<Shader> ShaderCache::Get(const std::string& vert,
+                                         const std::string& frag,
+                                         const std::string& geom)
+{
+    std::string key = makeKey(vert, frag, geom);
+    auto it = cache_.find(key);
+    if(it != cache_.end()){
+        if(auto sp = it->second.lock()) return sp;
+    }
+    const char* v = vert.empty() ? nullptr : vert.c_str();
+    const char* f = frag.empty() ? nullptr : frag.c_str();
+    const char* g = geom.empty() ? nullptr : geom.c_str();
+    auto shader = std::make_shared<Shader>(v,f,g);
+    cache_[key] = shader;
+    return shader;
+}
+
+void ShaderCache::Clear(){
+    cache_.clear();
+}

--- a/src/rendering/ShaderCache.h
+++ b/src/rendering/ShaderCache.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "Shader.h"
+
+class ShaderCache {
+public:
+    static std::shared_ptr<Shader> Get(const std::string& vert,
+                                       const std::string& frag,
+                                       const std::string& geom = "");
+    static void Clear();
+private:
+    static std::unordered_map<std::string, std::weak_ptr<Shader>> cache_;
+};

--- a/src/rendering/TextureCache.cpp
+++ b/src/rendering/TextureCache.cpp
@@ -1,0 +1,37 @@
+#include "TextureCache.h"
+#include <glad/glad.h>
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+std::unordered_map<std::string, std::weak_ptr<Texture>> TextureCache::cache_;
+
+std::shared_ptr<Texture> TextureCache::Get(const std::string& path, const std::string& type){
+    auto it = cache_.find(path);
+    if(it != cache_.end()){
+        if(auto sp = it->second.lock()) return sp;
+    }
+    int w,h,n;
+    unsigned char* data = stbi_load(path.c_str(), &w,&h,&n, 0);
+    if(!data){
+        return std::make_shared<Texture>();
+    }
+    auto tex = std::make_shared<Texture>();
+    tex->type = type;
+    tex->path = path;
+    glGenTextures(1, &tex->id);
+    GLenum fmt = (n==3 ? GL_RGB : GL_RGBA);
+    glBindTexture(GL_TEXTURE_2D, tex->id);
+    glTexImage2D(GL_TEXTURE_2D, 0, fmt, w, h, 0, fmt, GL_UNSIGNED_BYTE, data);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    stbi_image_free(data);
+    cache_[path] = tex;
+    return tex;
+}
+
+void TextureCache::Clear(){
+    cache_.clear();
+}

--- a/src/rendering/TextureCache.h
+++ b/src/rendering/TextureCache.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "Mesh.h"
+
+class TextureCache {
+public:
+    static std::shared_ptr<Texture> Get(const std::string& path, const std::string& type);
+    static void Clear();
+private:
+    static std::unordered_map<std::string, std::weak_ptr<Texture>> cache_;
+};

--- a/src/rendering/TextureLoader.cpp
+++ b/src/rendering/TextureLoader.cpp
@@ -1,36 +1,19 @@
 #include "TextureLoader.h"
+#include "TextureCache.h"
 #include <glad/glad.h>
-#define STB_IMAGE_IMPLEMENTATION
-#include "stb_image.h"
+#include <memory>
 
-std::vector<Texture> TextureLoader::LoadMaterialTextures(aiMaterial* mat,
+std::vector<std::shared_ptr<Texture>> TextureLoader::LoadMaterialTextures(aiMaterial* mat,
                                                          aiTextureType type,
                                                          const std::string& typeName,
                                                          const std::string& directory) const
 {
-    std::vector<Texture> ret;
+    std::vector<std::shared_ptr<Texture>> ret;
     for (unsigned i = 0; i < mat->GetTextureCount(type); ++i) {
         aiString str;
         mat->GetTexture(type, i, &str);
         std::string filename = directory + "/" + str.C_Str();
-        Texture tex;
-        tex.type = typeName;
-        tex.path = filename;
-        glGenTextures(1, &tex.id);
-        int w, h, n;
-        unsigned char* data = stbi_load(filename.c_str(), &w, &h, &n, 0);
-        if (data) {
-            GLenum fmt = (n == 3 ? GL_RGB : GL_RGBA);
-            glBindTexture(GL_TEXTURE_2D, tex.id);
-            glTexImage2D(GL_TEXTURE_2D, 0, fmt, w, h, 0, fmt, GL_UNSIGNED_BYTE, data);
-            glGenerateMipmap(GL_TEXTURE_2D);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            stbi_image_free(data);
-            ret.push_back(tex);
-        }
+        ret.push_back(TextureCache::Get(filename, typeName));
     }
     return ret;
 }

--- a/src/rendering/TextureLoader.h
+++ b/src/rendering/TextureLoader.h
@@ -1,12 +1,13 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <memory>
 #include <assimp/scene.h>
 #include "Mesh.h"
 
 class TextureLoader {
 public:
-    std::vector<Texture> LoadMaterialTextures(aiMaterial* mat,
+    std::vector<std::shared_ptr<Texture>> LoadMaterialTextures(aiMaterial* mat,
                                                aiTextureType type,
                                                const std::string& typeName,
                                                const std::string& directory) const;


### PR DESCRIPTION
## Summary
- cache textures so models reuse GPU resources
- refactor `Mesh` to store shared texture pointers
- update model loading path to use cached textures
- add `TextureCache` module and RAII deletion

## Testing
- `cmake -S . -B build` *(fails: could not find nlohmann_json)*
- `cmake --build build` *(fails: no makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_6845f5a495288321b1418a005be91460