### PR TITLE
Simplify process management

### DIFF
--- a/src/gcode/GCodeModel.cpp
+++ b/src/gcode/GCodeModel.cpp
@@ -89,7 +89,8 @@ void GCodeModel::DrawUpToLayer(int maxLayerIndex, Shader& lineShader) const {
     if (!ready_) return;
 
     int layerCount = static_cast<int>(layerVertexCounts_.size());
-    int end = (maxLayerIndex < 0 || maxLayerIndex >= layerCount) ? (layerCount - 1) : maxLayerIndex;
+    int end = maxLayerIndex < 0 ? layerCount - 1
+                                : std::clamp(maxLayerIndex, 0, layerCount - 1);
 
     lineShader.use();
     if (lineShader.hasUniform("lineColor")) {

--- a/src/utils/Pipe.h
+++ b/src/utils/Pipe.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <cstdio>
+#include <string>
+
+// Simple RAII wrapper for popen/_popen
+// Opens a read-only pipe and ensures it is closed.
+// Use get() to read from the pipe and close() to
+// retrieve the process return code.
+class Pipe {
+public:
+    explicit Pipe(const std::string &cmd) {
+#ifdef _WIN32
+        pipe_ = _popen(cmd.c_str(), "r");
+#else
+        pipe_ = popen(cmd.c_str(), "r");
+#endif
+    }
+    ~Pipe() { close(); }
+
+    Pipe(const Pipe&) = delete;
+    Pipe& operator=(const Pipe&) = delete;
+
+    bool valid() const { return pipe_ != nullptr; }
+    FILE* get() const { return pipe_; }
+
+    int close() {
+        if (!pipe_) return -1;
+#ifdef _WIN32
+        int ret = _pclose(pipe_);
+#else
+        int ret = pclose(pipe_);
+#endif
+        pipe_ = nullptr;
+        return ret;
+    }
+
+private:
+    FILE* pipe_ = nullptr;
+};


### PR DESCRIPTION
## Summary
- add a small `Pipe` RAII helper to manage popen/_popen
- simplify TripoSR and CuraEngine launch code using `Pipe`
- clamp G-code layer selection using `std::clamp`

## Testing
- `cmake -S . -B build` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_6845faa3b2d08321addbef81fad1d18c