### PR TITLE
Unify coordinate display using printer offset

### DIFF
--- a/src/controllers/GizmoController.cpp
+++ b/src/controllers/GizmoController.cpp
@@ -34,15 +34,18 @@ namespace
     class BasicOperation : public IGizmoOperation
     {
     public:
+        explicit BasicOperation(const glm::vec3 &off) : offset(off) {}
         void Apply(const glm::mat4 &m, ITransform &t) override
         {
             glm::vec3 tr, sc;
             glm::quat rot;
             DecomposeMatrix(m, tr, sc, rot);
-            t.setTranslation(tr);
+            t.setTranslation(tr - offset);
             t.setScale(sc);
             t.setRotationQuat(rot);
         }
+    private:
+        glm::vec3 offset;
     };
 
 } // namespace
@@ -50,7 +53,7 @@ namespace
 GizmoController::GizmoController()
     : currentOp_(ImGuizmo::TRANSLATE),
       currentMode_(ImGuizmo::LOCAL),
-      operation_(std::make_unique<BasicOperation>())
+      operation_(std::make_unique<BasicOperation>(offset_))
 {
 }
 
@@ -68,8 +71,8 @@ void GizmoController::Manipulate
     float windowHeight = ImGui::GetWindowHeight();
     ImGuizmo::SetRect(windowPos.x, windowPos.y, windowWidth, windowHeight);
 
-    // current model matrix
-    glm::mat4 model = glm::translate(glm::mat4(1.0f), transform.getTranslation())
+    // current model matrix with offset so the gizmo shows machine coordinates
+    glm::mat4 model = glm::translate(glm::mat4(1.0f), transform.getTranslation() + offset_)
                       * glm::toMat4(transform.getRotationQuat())
                       * glm::scale(glm::mat4(1.0f), transform.getScale());
 
@@ -108,5 +111,5 @@ void GizmoController::SetCurrentMode(ImGuizmo::OPERATION operation)
 
 void GizmoController::updateOperation()
 {
-    operation_ = std::make_unique<BasicOperation>();
+    operation_ = std::make_unique<BasicOperation>(offset_);
 }

--- a/src/controllers/GizmoController.h
+++ b/src/controllers/GizmoController.h
@@ -33,6 +33,8 @@ public:
 
     void SetCurrentMode(ImGuizmo::OPERATION operation);
 
+    void SetOffset(const glm::vec3 &off) { offset_ = off; }
+
 private:
     void updateOperation();
 
@@ -40,4 +42,5 @@ private:
     ImGuizmo::MODE currentMode_;
 
     std::unique_ptr<IGizmoOperation> operation_;
+    glm::vec3 offset_{0.0f};
 };

--- a/src/rendering/GridRenderer.cpp
+++ b/src/rendering/GridRenderer.cpp
@@ -30,7 +30,7 @@ void GridRenderer::Init(float halfX, float halfY)
                                       "../../resources/shaders/infinite_grid.frag");
 }
 
-void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj)
+void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     glEnable(GL_BLEND);
@@ -39,7 +39,8 @@ void GridRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj)
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    glm::mat4 model = glm::translate(glm::mat4(1.0f), offset);
+    shader_->setMat4("model", model);
     if (shader_->hasUniform("gridSpacing")) shader_->setFloat("gridSpacing", 5.0f);
     if (shader_->hasUniform("lineWidth")) shader_->setFloat("lineWidth", 0.5f);
     glBindVertexArray(vao_);

--- a/src/rendering/GridRenderer.h
+++ b/src/rendering/GridRenderer.h
@@ -10,7 +10,7 @@ public:
     ~GridRenderer();
 
     void Init(float halfX, float halfY);
-    void Render(const glm::mat4 &view, const glm::mat4 &proj);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &offset = glm::vec3(0.0f));
 
 private:
     GLuint vao_ = 0, vbo_ = 0, ebo_ = 0;

--- a/src/rendering/SceneRenderer.cpp
+++ b/src/rendering/SceneRenderer.cpp
@@ -21,6 +21,14 @@ SceneRenderer::SceneRenderer(const std::string &printerDefJsonPath)
                 volumeHalfX_ = w * 0.5f;
                 volumeHalfY_ = d * 0.5f;
                 volumeHeight_ = h;
+                if (j.contains("metadata") && j["metadata"].contains("platform_offset")) {
+                    auto arr = j["metadata"]["platform_offset"];
+                    if (arr.is_array() && arr.size() >= 3) {
+                        platformOffset_.x = arr[0].get<float>();
+                        platformOffset_.y = arr[1].get<float>();
+                        platformOffset_.z = arr[2].get<float>();
+                    }
+                }
             } catch (const std::exception &e) {
                 std::cerr << "Warning: JSON parse error in SceneRenderer constructor: "
                           << e.what() << "\nFalling back to defaults.\n";
@@ -127,14 +135,17 @@ void SceneRenderer::RenderModel(const Model &model, Shader &shader, const Transf
 
 void SceneRenderer::RenderGridAndVolume()
 {
-    gridRenderer_.Render(viewMatrix_, projectionMatrix_);
-    volumeBoxRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_);
+    gridRenderer_.Render(viewMatrix_, projectionMatrix_, platformOffset_);
+    volumeBoxRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_, platformOffset_);
     RenderAxes();
 }
 
 void SceneRenderer::RenderAxes()
 {
-    axesRenderer_.Render(viewMatrix_, projectionMatrix_, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.f));
+    axesRenderer_.Render(viewMatrix_, projectionMatrix_,
+                         glm::vec3(platformOffset_.x - volumeHalfX_,
+                                   platformOffset_.z - volumeHalfY_,
+                                   platformOffset_.y));
 }
 
 void SceneRenderer::RenderGCodeLayer(int layerIndex)
@@ -142,7 +153,11 @@ void SceneRenderer::RenderGCodeLayer(int layerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
-    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f) + gcodeOffset_);
+    modelMat = glm::translate(modelMat,
+                              glm::vec3(platformOffset_.x - volumeHalfX_,
+                                        platformOffset_.z - volumeHalfY_,
+                                        platformOffset_.y) +
+                                  gcodeOffset_);
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);
@@ -154,7 +169,11 @@ void SceneRenderer::RenderGCodeUpToLayer(int maxLayerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
-    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f) + gcodeOffset_);
+    modelMat = glm::translate(modelMat,
+                              glm::vec3(platformOffset_.x - volumeHalfX_,
+                                        platformOffset_.z - volumeHalfY_,
+                                        platformOffset_.y) +
+                                  gcodeOffset_);
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);

--- a/src/rendering/SceneRenderer.h
+++ b/src/rendering/SceneRenderer.h
@@ -34,6 +34,7 @@ public:
     float GetBedHalfWidth() const { return volumeHalfX_; }
     float GetBedHalfDepth() const { return volumeHalfY_; }
     float GetPrintHeight() const { return volumeHeight_; }
+    const glm::vec3 &GetPlatformOffset() const { return platformOffset_; }
 
     void SetGCodeModel(std::shared_ptr<GCodeModel> gcodeModel) { gcodeModel_ = gcodeModel; }
     void SetGCodeOffset(const glm::vec3& offset) { gcodeOffset_ = offset; }
@@ -61,6 +62,7 @@ private:
     float volumeHalfX_;
     float volumeHalfY_;
     float volumeHeight_;
+    glm::vec3 platformOffset_{0.0f};
 
     std::shared_ptr<GCodeModel> gcodeModel_;
     std::unique_ptr<Shader> gcodeShader_;

--- a/src/rendering/VolumeBoxRenderer.cpp
+++ b/src/rendering/VolumeBoxRenderer.cpp
@@ -27,13 +27,14 @@ void VolumeBoxRenderer::Init(float halfX, float halfY, float height)
                                        "../../resources/shaders/simple_line.frag");
 }
 
-void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color)
+void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color, const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    glm::mat4 model = glm::translate(glm::mat4(1.0f), offset);
+    shader_->setMat4("model", model);
     if (shader_->hasUniform("lineColor")) shader_->setVec3("lineColor", color);
     glBindVertexArray(vao_);
     glDrawArrays(GL_LINES, 0, 24);

--- a/src/rendering/VolumeBoxRenderer.h
+++ b/src/rendering/VolumeBoxRenderer.h
@@ -10,7 +10,7 @@ public:
     ~VolumeBoxRenderer();
 
     void Init(float halfX, float halfY, float height);
-    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color);
+    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color, const glm::vec3 &offset = glm::vec3(0.0f));
 
 private:
     GLuint vao_ = 0, vbo_ = 0;

--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -40,6 +40,10 @@ UIManager::UIManager(ModelManager& mm, SceneRenderer* renderer,
     : modelManager_(mm), renderer_(renderer), gizmo_(gizmo), camera_(camera), window_(window)
 {
     loadModelSettings();
+    if (renderer_)
+        gizmo_.SetOffset(glm::vec3(renderer_->GetBedHalfWidth() + renderer_->GetPlatformOffset().x,
+                                    renderer_->GetPlatformOffset().y,
+                                    renderer_->GetBedHalfDepth() + renderer_->GetPlatformOffset().z));
 }
 
 void UIManager::Frame() {
@@ -103,8 +107,8 @@ void UIManager::showMenuBar() {
                         gcodeModel_ = std::make_shared<GCodeModel>(selected);
                         if (renderer_) {
                             glm::vec3 c = gcodeModel_->GetCenter();
-                            glm::vec3 offset(renderer_->GetBedHalfWidth() - c.x,
-                                             renderer_->GetBedHalfDepth() - c.y,
+                            glm::vec3 offset(renderer_->GetBedHalfWidth() + renderer_->GetPlatformOffset().x - c.x,
+                                             renderer_->GetBedHalfDepth() + renderer_->GetPlatformOffset().z - c.y,
                                              0.f);
                             renderer_->SetGCodeOffset(offset);
                             renderer_->SetGCodeModel(gcodeModel_);


### PR DESCRIPTION
## Summary
- parse `platform_offset` from printer settings
- support gizmo offset so manipulator works in machine coordinates
- display translation values using the printer offset
- adjust slice reference calculation and gcode offsets
- offset grid/volume box rendering so the print bed shows the platform offset

## Testing
- `cmake ..` *(passes)*
- `make -j2` *(fails: missing imgui headers)*

------
https://chatgpt.com/codex/tasks/task_e_68460494ed608321a3abbd3ed9da70b0