### PR TITLE
Fix CuraEngine mesh positioning

### DIFF
--- a/src/ui/UIManagerHelpers.cpp
+++ b/src/ui/UIManagerHelpers.cpp
@@ -278,7 +278,23 @@ void UIManager::sliceActiveModel()
             std::lock_guard lk(slicingMessageMutex_);
             slicingMessage_ = "model_settings.json not found.";
             }
+        // Export without applying translation so that CuraEngine can position the
+        // mesh using the mesh_position_x/y overrides only once.
+        glm::vec3 origTranslation(0.f);
+        Transform *exportTf = modelManager_.GetTransform(slicingModelIndex_);
+        if (exportTf)
+            {
+            origTranslation = exportTf->getTranslation();
+            exportTf->setTranslation(glm::vec3(0.f));
+            }
+
         modelManager_.ExportTransformedModel(slicingModelIndex_, pendingResizedPath_);
+
+        if (exportTf)
+            {
+            exportTf->setTranslation(origTranslation);
+            }
+
         float offX = renderer_ ? renderer_->GetBedHalfWidth() : 0.f;
         float offY = renderer_ ? renderer_->GetBedHalfDepth() : 0.f;
 


### PR DESCRIPTION
## Summary
- avoid baking translation into exported STL when slicing
- compute mesh offset from current model position for CuraEngine

## Testing
- `cmake -S . -B build` *(fails: missing submodules and packages)*

------
https://chatgpt.com/codex/tasks/task_e_68460c7f7dac8321b476cb63d99df531