### PR TITLE
Use TextureCache for generated white texture

### DIFF
--- a/src/rendering/SceneRenderer.cpp
+++ b/src/rendering/SceneRenderer.cpp
@@ -49,20 +49,11 @@ SceneRenderer::SceneRenderer(const std::string &printerDefJsonPath)
     SetViewportSize(viewportWidth_, viewportHeight_);
 }
 
-SceneRenderer::~SceneRenderer()
-{
-    if (defaultWhiteTex_) glDeleteTextures(1, &defaultWhiteTex_);
-}
+SceneRenderer::~SceneRenderer() = default;
 
 void SceneRenderer::InitializeDefaultTexture()
 {
-    glGenTextures(1, &defaultWhiteTex_);
-    glBindTexture(GL_TEXTURE_2D, defaultWhiteTex_);
-    unsigned char whitePixel[4] = {255,255,255,255};
-    glTexImage2D(GL_TEXTURE_2D,0,GL_RGBA,1,1,0,GL_RGBA,GL_UNSIGNED_BYTE,whitePixel);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_2D,0);
+    defaultWhiteTex_ = TextureCache::GetSolidColorTexture(255, 255, 255, 255);
 }
 
 
@@ -119,7 +110,7 @@ void SceneRenderer::RenderModel(const Model &model, Shader &shader, const Transf
     if (shader.hasUniform("viewPos")) shader.setVec3("viewPos", cameraWorldPosition);
     if (shader.hasUniform("lightPos")) shader.setVec3("lightPos", cameraWorldPosition);
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, defaultWhiteTex_);
+    glBindTexture(GL_TEXTURE_2D, defaultWhiteTex_ ? defaultWhiteTex_->id : 0);
     if (shader.hasUniform("texture_diffuse1")) shader.setInt("texture_diffuse1",0);
     if (shader.hasUniform("objectColor")) shader.setVec4("objectColor", glm::vec4(0.7f,0.7f,0.7f,1.0f));
     model.Draw(shader);

--- a/src/rendering/SceneRenderer.h
+++ b/src/rendering/SceneRenderer.h
@@ -8,6 +8,7 @@
 #include "VolumeBoxRenderer.h"
 #include "AxesRenderer.h"
 #include "FrameBuffer.h"
+#include "TextureCache.h"
 using json = nlohmann::json;
 
 class Shader;
@@ -48,7 +49,7 @@ private:
     void RenderAxes();
 
     FrameBuffer framebuffer_;
-    GLuint     defaultWhiteTex_ = 0;
+    std::shared_ptr<Texture> defaultWhiteTex_;
 
     glm::vec3 gridColor_ = glm::vec3(0.4f, 0.4f, 0.45f);
     int viewportWidth_ = 1;

--- a/src/rendering/TextureCache.cpp
+++ b/src/rendering/TextureCache.cpp
@@ -32,6 +32,34 @@ std::shared_ptr<Texture> TextureCache::Get(const std::string& path, const std::s
     return tex;
 }
 
+std::shared_ptr<Texture> TextureCache::GetSolidColorTexture(unsigned char r,
+                                                             unsigned char g,
+                                                             unsigned char b,
+                                                             unsigned char a)
+{
+    std::string key = "solid:" + std::to_string(r) + '_' +
+                      std::to_string(g) + '_' +
+                      std::to_string(b) + '_' +
+                      std::to_string(a);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+        if (auto sp = it->second.lock()) return sp;
+    }
+    auto tex = std::make_shared<Texture>();
+    tex->type = "solid";
+    tex->path = key;
+    glGenTextures(1, &tex->id);
+    unsigned char pixel[4] = { r, g, b, a };
+    glBindTexture(GL_TEXTURE_2D, tex->id);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 pixel);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    cache_[key] = tex;
+    return tex;
+}
+
 void TextureCache::Clear(){
     cache_.clear();
 }

--- a/src/rendering/TextureCache.h
+++ b/src/rendering/TextureCache.h
@@ -7,6 +7,10 @@
 class TextureCache {
 public:
     static std::shared_ptr<Texture> Get(const std::string& path, const std::string& type);
+    static std::shared_ptr<Texture> GetSolidColorTexture(unsigned char r,
+                                                         unsigned char g,
+                                                         unsigned char b,
+                                                         unsigned char a);
     static void Clear();
 private:
     static std::unordered_map<std::string, std::weak_ptr<Texture>> cache_;


### PR DESCRIPTION
## Summary
- expose a new `GetSolidColorTexture` in `TextureCache`
- use this helper in `SceneRenderer` for the default white texture
- hold the default texture as a shared pointer

## Testing
- `cmake -S . -B build` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_684b250d6a5c83218076d3071fafa290