### PR TITLE
Add multisample framebuffer and mipmaps

### DIFF
--- a/src/controllers/WindowManager.cpp
+++ b/src/controllers/WindowManager.cpp
@@ -120,6 +120,7 @@ void WindowManager::InitGLFW() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_SAMPLES, 4);
 }
 
 void WindowManager::InitWindow(const char* title, int w, int h) {
@@ -141,6 +142,7 @@ void WindowManager::InitGLAD() {
     }
     glEnable(GL_LINE_SMOOTH);
     glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+    glEnable(GL_MULTISAMPLE);
     glEnable(GL_DEPTH_TEST);
 }
 

--- a/src/rendering/FrameBuffer.cpp
+++ b/src/rendering/FrameBuffer.cpp
@@ -3,29 +3,57 @@
 
 FrameBuffer::~FrameBuffer()
 {
+    if (msFbo_) glDeleteFramebuffers(1, &msFbo_);
+    if (msColorTex_) glDeleteTextures(1, &msColorTex_);
+    if (msDepthStencilRBO_) glDeleteRenderbuffers(1, &msDepthStencilRBO_);
     if (fbo_) glDeleteFramebuffers(1, &fbo_);
     if (colorTex_) glDeleteTextures(1, &colorTex_);
     if (depthStencilRBO_) glDeleteRenderbuffers(1, &depthStencilRBO_);
 }
 
-void FrameBuffer::Init(int width, int height)
+void FrameBuffer::Init(int width, int height, int samples)
 {
+    samples_ = samples;
+    width_ = width;
+    height_ = height;
+
+    glGenFramebuffers(1, &msFbo_);
+    glGenTextures(1, &msColorTex_);
+    glGenRenderbuffers(1, &msDepthStencilRBO_);
+
     glGenFramebuffers(1, &fbo_);
     glGenTextures(1, &colorTex_);
     glGenRenderbuffers(1, &depthStencilRBO_);
+
     Resize(width, height);
 }
 
 void FrameBuffer::Resize(int width, int height)
 {
-    if (!fbo_) Init(width, height); // ensure created
+    width_ = width;
+    height_ = height;
+    if (!fbo_ || !msFbo_) return;
+
+    // multisample framebuffer
+    glBindFramebuffer(GL_FRAMEBUFFER, msFbo_);
+    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msColorTex_);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples_, GL_RGBA8, width, height, GL_TRUE);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, msColorTex_, 0);
+    glBindRenderbuffer(GL_RENDERBUFFER, msDepthStencilRBO_);
+    glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples_, GL_DEPTH24_STENCIL8, width, height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, msDepthStencilRBO_);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        std::cerr << "MS Framebuffer not complete!" << std::endl;
+
+    // resolved framebuffer
     glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
     glBindTexture(GL_TEXTURE_2D, colorTex_);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glGenerateMipmap(GL_TEXTURE_2D);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex_, 0);
 
     glBindRenderbuffer(GL_RENDERBUFFER, depthStencilRBO_);
@@ -33,6 +61,7 @@ void FrameBuffer::Resize(int width, int height)
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthStencilRBO_);
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
         std::cerr << "Framebuffer not complete!" << std::endl;
+
     glBindTexture(GL_TEXTURE_2D, 0);
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -40,10 +69,15 @@ void FrameBuffer::Resize(int width, int height)
 
 void FrameBuffer::Bind()
 {
-    glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
+    glBindFramebuffer(GL_FRAMEBUFFER, msFbo_ ? msFbo_ : fbo_);
 }
 
 void FrameBuffer::Unbind()
 {
+    if (msFbo_) {
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, msFbo_);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo_);
+        glBlitFramebuffer(0, 0, width_, height_, 0, 0, width_, height_, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+    }
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }

--- a/src/rendering/FrameBuffer.h
+++ b/src/rendering/FrameBuffer.h
@@ -6,7 +6,7 @@ public:
     FrameBuffer() = default;
     ~FrameBuffer();
 
-    void Init(int width, int height);
+    void Init(int width, int height, int samples = 4);
     void Resize(int width, int height);
     void Bind();
     void Unbind();
@@ -14,7 +14,15 @@ public:
     GLuint GetColorTexture() const { return colorTex_; }
 
 private:
-    GLuint fbo_ = 0;
+    GLuint fbo_ = 0; // resolved framebuffer
     GLuint colorTex_ = 0;
     GLuint depthStencilRBO_ = 0;
+
+    GLuint msFbo_ = 0; // multisample framebuffer
+    GLuint msColorTex_ = 0;
+    GLuint msDepthStencilRBO_ = 0;
+
+    int width_ = 0;
+    int height_ = 0;
+    int samples_ = 4;
 };

--- a/src/rendering/SceneRenderer.cpp
+++ b/src/rendering/SceneRenderer.cpp
@@ -35,7 +35,7 @@ SceneRenderer::SceneRenderer(const std::string &printerDefJsonPath)
     }
 
     InitializeDefaultTexture();
-    framebuffer_.Init(viewportWidth_, viewportHeight_);
+    framebuffer_.Init(viewportWidth_, viewportHeight_, 4);
     InitializeGrid();
     InitializeVolumeBox();
     InitializeAxes();


### PR DESCRIPTION
## Summary
- enable multisampling on the GLFW window and GL context
- add support for multisampled offscreen frame buffer with mipmap generation

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_684b27402b048321b6189515fc828a21