### PR TITLE
Implement deferred shading and anisotropic filtering

### DIFF
--- a/resources/shaders/deferred_geom.frag
+++ b/resources/shaders/deferred_geom.frag
@@ -1,0 +1,14 @@
+#version 330 core
+layout(location = 0) out vec3 gPosition;
+layout(location = 1) out vec3 gNormal;
+layout(location = 2) out vec4 gAlbedo;
+
+in vec3 FragPos;
+in vec3 Normal;
+in vec4 Albedo;
+
+void main(){
+    gPosition = FragPos;
+    gNormal = normalize(Normal);
+    gAlbedo = Albedo;
+}

--- a/resources/shaders/deferred_geom.vert
+++ b/resources/shaders/deferred_geom.vert
@@ -1,0 +1,21 @@
+#version 330 core
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec3 aNormal;
+layout(location = 2) in vec2 aTex;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+uniform vec4 objectColor = vec4(0.7,0.7,0.7,1.0);
+
+out vec3 FragPos;
+out vec3 Normal;
+out vec4 Albedo;
+
+void main(){
+    vec4 world = model * vec4(aPos,1.0);
+    FragPos = world.xyz;
+    Normal = mat3(transpose(inverse(model))) * aNormal;
+    Albedo = objectColor;
+    gl_Position = projection * view * world;
+}

--- a/resources/shaders/deferred_light.frag
+++ b/resources/shaders/deferred_light.frag
@@ -1,0 +1,31 @@
+#version 330 core
+out vec4 FragColor;
+
+in vec2 TexCoords;
+
+uniform sampler2D gPosition;
+uniform sampler2D gNormal;
+uniform sampler2D gAlbedo;
+
+uniform vec3 lightDir;
+uniform vec3 lightPos;
+uniform vec3 viewPos;
+
+void main(){
+    vec3 FragPos = texture(gPosition, TexCoords).rgb;
+    vec3 Normal  = texture(gNormal, TexCoords).rgb;
+    vec4 Albedo  = texture(gAlbedo, TexCoords);
+    vec3 N = normalize(Normal);
+    vec3 Ld = normalize(-lightDir);
+    vec3 Lp = normalize(lightPos - FragPos);
+    vec3 L  = normalize(Ld + Lp);
+    vec3 ambient = 0.2 * Albedo.rgb;
+    float diff = max(dot(N,L),0.0);
+    vec3 diffuse = diff * Albedo.rgb;
+    vec3 V = normalize(viewPos - FragPos);
+    vec3 R = reflect(-L, N);
+    float spec = pow(max(dot(V,R),0.0),32.0);
+    vec3 specular = 0.5 * spec * vec3(1.0);
+    vec3 color = ambient + diffuse + specular;
+    FragColor = vec4(color, Albedo.a);
+}

--- a/resources/shaders/deferred_light.vert
+++ b/resources/shaders/deferred_light.vert
@@ -1,0 +1,10 @@
+#version 330 core
+layout(location = 0) in vec2 aPos;
+layout(location = 1) in vec2 aTex;
+
+out vec2 TexCoords;
+
+void main(){
+    TexCoords = aTex;
+    gl_Position = vec4(aPos,0.0,1.0);
+}

--- a/src/rendering/SceneRenderer.cpp
+++ b/src/rendering/SceneRenderer.cpp
@@ -6,6 +6,8 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <iostream>
+#include <vector>
+
 
 SceneRenderer::SceneRenderer(const std::string &printerDefJsonPath)
 {
@@ -46,10 +48,31 @@ SceneRenderer::SceneRenderer(const std::string &printerDefJsonPath)
         std::cerr << "CRITICAL Error loading shaders in SceneRenderer: " << e.what() << std::endl;
         gcodeShader_.reset();
     }
+    try {
+        deferredGeomShader_ = std::make_unique<Shader>("../../resources/shaders/deferred_geom.vert",
+                                                       "../../resources/shaders/deferred_geom.frag");
+        deferredLightingShader_ = std::make_unique<Shader>("../../resources/shaders/deferred_light.vert",
+                                                           "../../resources/shaders/deferred_light.frag");
+    } catch (const std::exception &e) {
+        std::cerr << "CRITICAL Error loading deferred shaders: " << e.what() << std::endl;
+        deferredGeomShader_.reset();
+        deferredLightingShader_.reset();
+    }
+    InitGBuffer();
+    InitQuad();
     SetViewportSize(viewportWidth_, viewportHeight_);
 }
 
-SceneRenderer::~SceneRenderer() = default;
+SceneRenderer::~SceneRenderer()
+{
+    if (gPosition_) glDeleteTextures(1, &gPosition_);
+    if (gNormal_) glDeleteTextures(1, &gNormal_);
+    if (gAlbedo_) glDeleteTextures(1, &gAlbedo_);
+    if (gDepthRBO_) glDeleteRenderbuffers(1, &gDepthRBO_);
+    if (gBuffer_) glDeleteFramebuffers(1, &gBuffer_);
+    if (quadVAO_) glDeleteVertexArrays(1, &quadVAO_);
+    if (quadVBO_) glDeleteBuffers(1, &quadVBO_);
+}
 
 void SceneRenderer::InitializeDefaultTexture()
 {
@@ -78,6 +101,7 @@ void SceneRenderer::SetViewportSize(int width, int height)
     if (height <= 0) height = 1;
     viewportWidth_ = width; viewportHeight_ = height;
     framebuffer_.Resize(width, height);
+    ResizeGBuffer(width, height);
     projectionMatrix_ = glm::perspective(glm::radians(45.f), static_cast<float>(width)/static_cast<float>(height), 0.1f, 1000.f);
 }
 
@@ -85,7 +109,8 @@ void SceneRenderer::SetViewportSize(int width, int height)
 void SceneRenderer::BeginScene(const glm::mat4 &viewMatrix, const glm::vec3 &)
 {
     viewMatrix_ = viewMatrix;
-    framebuffer_.Bind();
+    inGeometryPass_ = true;
+    glBindFramebuffer(GL_FRAMEBUFFER, gBuffer_);
     glViewport(0,0,viewportWidth_,viewportHeight_);
     glClearColor(0.10f,0.105f,0.11f,1.0f);
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
@@ -95,25 +120,54 @@ void SceneRenderer::BeginScene(const glm::mat4 &viewMatrix, const glm::vec3 &)
 
 void SceneRenderer::EndScene()
 {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    inGeometryPass_ = false;
+
+    framebuffer_.Bind();
+    glDisable(GL_DEPTH_TEST);
+    if (deferredLightingShader_ && quadVAO_) {
+        deferredLightingShader_->use();
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, gPosition_);
+        deferredLightingShader_->setInt("gPosition",0);
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, gNormal_);
+        deferredLightingShader_->setInt("gNormal",1);
+        glActiveTexture(GL_TEXTURE2);
+        glBindTexture(GL_TEXTURE_2D, gAlbedo_);
+        deferredLightingShader_->setInt("gAlbedo",2);
+        glm::vec3 camPos = glm::vec3(glm::inverse(viewMatrix_)[3]);
+        if (deferredLightingShader_->hasUniform("lightDir"))
+            deferredLightingShader_->setVec3("lightDir", lightDirection_);
+        if (deferredLightingShader_->hasUniform("lightPos"))
+            deferredLightingShader_->setVec3("lightPos", camPos);
+        if (deferredLightingShader_->hasUniform("viewPos"))
+            deferredLightingShader_->setVec3("viewPos", camPos);
+        RenderQuad();
+    }
     framebuffer_.Unbind();
+    glEnable(GL_DEPTH_TEST);
 }
 
 void SceneRenderer::RenderModel(const Model &model, Shader &shader, const Transform &transform)
 {
-    if (shader.ID == 0) return;
-    shader.use();
-    shader.setMat4("view", viewMatrix_);
-    shader.setMat4("projection", projectionMatrix_);
-    shader.setMat4("model", transform.getMatrix());
+    Shader* useShader = inGeometryPass_ ? deferredGeomShader_.get() : &shader;
+    if (!useShader || useShader->ID == 0) return;
+    useShader->use();
+    useShader->setMat4("view", viewMatrix_);
+    useShader->setMat4("projection", projectionMatrix_);
+    useShader->setMat4("model", transform.getMatrix());
     glm::vec3 cameraWorldPosition = glm::vec3(glm::inverse(viewMatrix_)[3]);
-    if (shader.hasUniform("lightDir")) shader.setVec3("lightDir", lightDirection_);
-    if (shader.hasUniform("viewPos")) shader.setVec3("viewPos", cameraWorldPosition);
-    if (shader.hasUniform("lightPos")) shader.setVec3("lightPos", cameraWorldPosition);
+    if (!inGeometryPass_) {
+        if (useShader->hasUniform("lightDir")) useShader->setVec3("lightDir", lightDirection_);
+        if (useShader->hasUniform("viewPos")) useShader->setVec3("viewPos", cameraWorldPosition);
+        if (useShader->hasUniform("lightPos")) useShader->setVec3("lightPos", cameraWorldPosition);
+    }
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, defaultWhiteTex_ ? defaultWhiteTex_->id : 0);
-    if (shader.hasUniform("texture_diffuse1")) shader.setInt("texture_diffuse1",0);
-    if (shader.hasUniform("objectColor")) shader.setVec4("objectColor", glm::vec4(0.7f,0.7f,0.7f,1.0f));
-    model.Draw(shader);
+    if (useShader->hasUniform("texture_diffuse1")) useShader->setInt("texture_diffuse1",0);
+    if (useShader->hasUniform("objectColor")) useShader->setVec4("objectColor", glm::vec4(0.7f,0.7f,0.7f,1.0f));
+    model.Draw(*useShader);
 }
 
 void SceneRenderer::RenderGridAndVolume()
@@ -150,4 +204,79 @@ void SceneRenderer::RenderGCodeUpToLayer(int maxLayerIndex)
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);
     gcodeModel_->DrawUpToLayer(maxLayerIndex, *gcodeShader_);
+}
+
+void SceneRenderer::InitGBuffer()
+{
+    glGenFramebuffers(1, &gBuffer_);
+    glGenTextures(1, &gPosition_);
+    glGenTextures(1, &gNormal_);
+    glGenTextures(1, &gAlbedo_);
+    glGenRenderbuffers(1, &gDepthRBO_);
+    ResizeGBuffer(viewportWidth_, viewportHeight_);
+}
+
+void SceneRenderer::ResizeGBuffer(int width, int height)
+{
+    if (!gBuffer_) return;
+    glBindFramebuffer(GL_FRAMEBUFFER, gBuffer_);
+
+    glBindTexture(GL_TEXTURE_2D, gPosition_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, width, height, 0, GL_RGB, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, gPosition_, 0);
+
+    glBindTexture(GL_TEXTURE_2D, gNormal_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, width, height, 0, GL_RGB, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, gNormal_, 0);
+
+    glBindTexture(GL_TEXTURE_2D, gAlbedo_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_2D, gAlbedo_, 0);
+
+    GLuint attachments[3] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2 };
+    glDrawBuffers(3, attachments);
+
+    glBindRenderbuffer(GL_RENDERBUFFER, gDepthRBO_);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, gDepthRBO_);
+
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        std::cerr << "GBuffer not complete!" << std::endl;
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void SceneRenderer::InitQuad()
+{
+    float quadVertices[] = {
+        -1.0f,  1.0f, 0.0f, 1.0f,
+        -1.0f, -1.0f, 0.0f, 0.0f,
+         1.0f, -1.0f, 1.0f, 0.0f,
+        -1.0f,  1.0f, 0.0f, 1.0f,
+         1.0f, -1.0f, 1.0f, 0.0f,
+         1.0f,  1.0f, 1.0f, 1.0f
+    };
+    glGenVertexArrays(1, &quadVAO_);
+    glGenBuffers(1, &quadVBO_);
+    glBindVertexArray(quadVAO_);
+    glBindBuffer(GL_ARRAY_BUFFER, quadVBO_);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), quadVertices, GL_STATIC_DRAW);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
+    glEnableVertexAttribArray(1);
+    glBindVertexArray(0);
+}
+
+void SceneRenderer::RenderQuad()
+{
+    glBindVertexArray(quadVAO_);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
 }

--- a/src/rendering/SceneRenderer.h
+++ b/src/rendering/SceneRenderer.h
@@ -47,9 +47,27 @@ private:
     void InitializeAxes();
     void RenderGridAndVolume();
     void RenderAxes();
+    void InitGBuffer();
+    void ResizeGBuffer(int width, int height);
+    void InitQuad();
+    void RenderQuad();
 
     FrameBuffer framebuffer_;
     std::shared_ptr<Texture> defaultWhiteTex_;
+
+    GLuint gBuffer_ = 0;
+    GLuint gPosition_ = 0;
+    GLuint gNormal_ = 0;
+    GLuint gAlbedo_ = 0;
+    GLuint gDepthRBO_ = 0;
+
+    GLuint quadVAO_ = 0;
+    GLuint quadVBO_ = 0;
+
+    std::unique_ptr<Shader> deferredGeomShader_;
+    std::unique_ptr<Shader> deferredLightingShader_;
+
+    bool inGeometryPass_ = false;
 
     glm::vec3 gridColor_ = glm::vec3(0.4f, 0.4f, 0.45f);
     int viewportWidth_ = 1;

--- a/src/rendering/TextureCache.cpp
+++ b/src/rendering/TextureCache.cpp
@@ -23,6 +23,9 @@ std::shared_ptr<Texture> TextureCache::Get(const std::string& path, const std::s
     glBindTexture(GL_TEXTURE_2D, tex->id);
     glTexImage2D(GL_TEXTURE_2D, 0, fmt, w, h, 0, fmt, GL_UNSIGNED_BYTE, data);
     glGenerateMipmap(GL_TEXTURE_2D);
+    GLfloat maxAniso = 0.0f;
+    glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);


### PR DESCRIPTION
## Summary
- add deferred shading pipeline using a G-buffer and fullscreen lighting pass
- support anisotropic filtering when loading textures

## Testing
- `cmake -B build` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_684b3a4ad96483218a381e72774a32bd