### PR TITLE
Add async model loading to keep UI responsive

### DIFF
--- a/src/ui/UIManager.cpp
+++ b/src/ui/UIManager.cpp
@@ -52,6 +52,7 @@ void UIManager::Frame() {
     openRenderScene();
     showGenerationModal();
     showSlicingModal();
+    showLoadingModal();
     showErrorModal(errorModalMessage_);
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
@@ -95,7 +96,7 @@ void UIManager::showMenuBar() {
     if (ImGui::BeginMainMenuBar()) {
         if (ImGui::BeginMenu("File")) {
             if (ImGui::MenuItem("Open 3D Model")) {
-                openFileDialog([this](std::string& selected){ loadModel(selected); });
+                openFileDialog([this](std::string& selected){ loadModelAsync(selected); });
             }
             if (ImGui::MenuItem("Open G-code")) {
                 openFileDialog([this](std::string& selected){

--- a/src/ui/UIManager.h
+++ b/src/ui/UIManager.h
@@ -46,7 +46,9 @@ private:
 
     void saveModelSettings();
 
-    void loadModel(std::string &modelPath);
+    void loadModelSync(std::string &modelPath);
+    void loadModelAsync(std::string modelPath);
+    void showLoadingModal();
 
     void loadImageFor3DModel(std::string &imagePath);
 
@@ -92,6 +94,11 @@ private:
     std::string slicingMessage_;
     std::mutex slicingMessageMutex_;
     std::atomic<float> slicingProgress_{0.0f};
+
+    std::atomic<bool> loadingModel_{false};
+    std::atomic<bool> loadingDone_{false};
+    std::string loadingMessage_;
+    std::mutex loadingMessageMutex_;
 
     bool showWireframe_ = false;
     bool useOrtho_ = false;


### PR DESCRIPTION
## Summary
- avoid blocking UI by loading models in a background thread
- display a simple modal while models load
- hook up async loading when opening models and after model generation

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_684c9153b2b08321802e9ba084a52646