### PR TITLE
Fix slice alignment by honoring platform offset

### DIFF
--- a/src/rendering/GridRenderer.cpp
+++ b/src/rendering/GridRenderer.cpp
@@ -42,7 +42,8 @@ void GridRenderer::Init(float halfX, float halfY)
  */
 void GridRenderer::Render(const glm::mat4 &view,
                           const glm::mat4 &proj,
-                          const glm::vec3 &lineColor)
+                          const glm::vec3 &lineColor,
+                          const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     glEnable(GL_BLEND);
@@ -51,7 +52,8 @@ void GridRenderer::Render(const glm::mat4 &view,
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    glm::mat4 modelMat = glm::translate(glm::mat4(1.0f), offset);
+    shader_->setMat4("model", modelMat);
     if (shader_->hasUniform("gridSpacing"))
         shader_->setFloat("gridSpacing", 5.0f);
     if (shader_->hasUniform("lineWidthFactor"))

--- a/src/rendering/GridRenderer.h
+++ b/src/rendering/GridRenderer.h
@@ -22,7 +22,8 @@ public:
      */
     void Render(const glm::mat4 &view,
                 const glm::mat4 &proj,
-                const glm::vec3 &lineColor);
+                const glm::vec3 &lineColor,
+                const glm::vec3 &offset = glm::vec3(0.0f));
 
 private:
     GLuint vao_ = 0, vbo_ = 0, ebo_ = 0;

--- a/src/rendering/SceneRenderer.cpp
+++ b/src/rendering/SceneRenderer.cpp
@@ -29,6 +29,15 @@ SceneRenderer::SceneRenderer(const std::string &printerDefJsonPath)
                 volumeHalfX_ = w * 0.5f;
                 volumeHalfY_ = d * 0.5f;
                 volumeHeight_ = h;
+                if (j.contains("metadata") && j["metadata"].contains("platform_offset")) {
+                    auto arr = j["metadata"]["platform_offset"];
+                    if (arr.is_array() && arr.size() >= 2) {
+                        platformOffset_.x = static_cast<float>(arr[0].get<double>());
+                        platformOffset_.y = static_cast<float>(arr[1].get<double>());
+                        if (arr.size() >= 3)
+                            platformOffset_.z = static_cast<float>(arr[2].get<double>());
+                    }
+                }
             } catch (const std::exception &e) {
                 std::cerr << "Warning: JSON parse error in SceneRenderer constructor: "
                           << e.what() << "\nFalling back to defaults.\n";
@@ -137,15 +146,18 @@ void SceneRenderer::RenderModel(const Model &model, Shader &shader, const Transf
 /** Draw the ground grid and build volume. */
 void SceneRenderer::RenderGridAndVolume()
 {
-    gridRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_);
-    volumeBoxRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_);
+    gridRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_, platformOffset_);
+    volumeBoxRenderer_.Render(viewMatrix_, projectionMatrix_, gridColor_, platformOffset_);
     RenderAxes();
 }
 
 /** Draw the small axis widget. */
 void SceneRenderer::RenderAxes()
 {
-    axesRenderer_.Render(viewMatrix_, projectionMatrix_, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.f));
+    axesRenderer_.Render(viewMatrix_, projectionMatrix_,
+                         glm::vec3(-volumeHalfX_ + platformOffset_.x,
+                                   -volumeHalfY_ + platformOffset_.y,
+                                   0.f));
 }
 
 /** Render only a specific G-code layer. */
@@ -154,7 +166,8 @@ void SceneRenderer::RenderGCodeLayer(int layerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
-    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f) + gcodeOffset_);
+    glm::vec3 base(-volumeHalfX_, -volumeHalfY_, 0.0f);
+    modelMat = glm::translate(modelMat, base + platformOffset_ + gcodeOffset_);
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);
@@ -167,7 +180,8 @@ void SceneRenderer::RenderGCodeUpToLayer(int maxLayerIndex)
     if (!gcodeModel_ || !gcodeShader_) return;
     gcodeShader_->use();
     glm::mat4 modelMat(1.0f);
-    modelMat = glm::translate(modelMat, glm::vec3(-volumeHalfX_, -volumeHalfY_, 0.0f) + gcodeOffset_);
+    glm::vec3 base(-volumeHalfX_, -volumeHalfY_, 0.0f);
+    modelMat = glm::translate(modelMat, base + platformOffset_ + gcodeOffset_);
     gcodeShader_->setMat4("model", modelMat);
     gcodeShader_->setMat4("view", viewMatrix_);
     gcodeShader_->setMat4("projection", projectionMatrix_);

--- a/src/rendering/SceneRenderer.h
+++ b/src/rendering/SceneRenderer.h
@@ -44,6 +44,7 @@ public:
     float GetBedHalfWidth() const { return volumeHalfX_; }
     float GetBedHalfDepth() const { return volumeHalfY_; }
     float GetPrintHeight() const { return volumeHeight_; }
+    const glm::vec3 &GetPlatformOffset() const { return platformOffset_; }
 
     void SetGCodeModel(std::shared_ptr<GCodeModel> gcodeModel) { gcodeModel_ = gcodeModel; }
     void SetGCodeOffset(const glm::vec3& offset) { gcodeOffset_ = offset; }
@@ -77,6 +78,8 @@ private:
     float volumeHalfX_;
     float volumeHalfY_;
     float volumeHeight_;
+
+    glm::vec3 platformOffset_ = glm::vec3(0.0f);
 
     std::shared_ptr<GCodeModel> gcodeModel_;
     std::unique_ptr<Shader> gcodeShader_;

--- a/src/rendering/VolumeBoxRenderer.cpp
+++ b/src/rendering/VolumeBoxRenderer.cpp
@@ -35,13 +35,17 @@ void VolumeBoxRenderer::Init(float halfX, float halfY, float height)
 }
 
 /** Render the volume box. */
-void VolumeBoxRenderer::Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color)
+void VolumeBoxRenderer::Render(const glm::mat4 &view,
+                               const glm::mat4 &proj,
+                               const glm::vec3 &color,
+                               const glm::vec3 &offset)
 {
     if (!shader_ || vao_ == 0) return;
     shader_->use();
     shader_->setMat4("view", view);
     shader_->setMat4("projection", proj);
-    shader_->setMat4("model", glm::mat4(1.0f));
+    glm::mat4 modelMat = glm::translate(glm::mat4(1.0f), offset);
+    shader_->setMat4("model", modelMat);
     if (shader_->hasUniform("lineColor")) shader_->setVec3("lineColor", color);
     glBindVertexArray(vao_);
     glLineWidth(lineWidth_);

--- a/src/rendering/VolumeBoxRenderer.h
+++ b/src/rendering/VolumeBoxRenderer.h
@@ -16,7 +16,10 @@ public:
     void Init(float halfX, float halfY, float height);
     void SetLineWidth(float width) { lineWidth_ = width; }
     /** Render the box with the provided matrices and color. */
-    void Render(const glm::mat4 &view, const glm::mat4 &proj, const glm::vec3 &color);
+    void Render(const glm::mat4 &view,
+                const glm::mat4 &proj,
+                const glm::vec3 &color,
+                const glm::vec3 &offset = glm::vec3(0.0f));
 
 private:
     GLuint vao_ = 0, vbo_ = 0;

--- a/src/ui/UIManagerHelpers.cpp
+++ b/src/ui/UIManagerHelpers.cpp
@@ -316,11 +316,11 @@ void UIManager::sliceActiveModel()
                     {
                     glm::vec3 localCenter = mdl->center;
                     glm::vec3 worldCenter = glm::vec3(tf->getMatrix() * glm::vec4(localCenter, 1.0f));
-                    worldCenter.x = glm::clamp(worldCenter.x, -offX, +offX);
-                    worldCenter.y = glm::clamp(worldCenter.y, -offY, +offY);
-                    std::cout << "World center: " << worldCenter.x << ", " << worldCenter.y << std::endl;
-                    double posX = offX + worldCenter.x;
-                    double posY = offY + worldCenter.y;
+                    float machineW = renderer_ ? renderer_->GetBedHalfWidth()*2.f : offX*2.f;
+                    float machineD = renderer_ ? renderer_->GetBedHalfDepth()*2.f : offY*2.f;
+                    glm::vec3 plat = renderer_ ? renderer_->GetPlatformOffset() : glm::vec3(0.0f);
+                    double posX = glm::clamp(worldCenter.x - plat.x, 0.0f, static_cast<double>(machineW));
+                    double posY = glm::clamp(worldCenter.y - plat.y, 0.0f, static_cast<double>(machineD));
                     modelSettings_["overrides"]["mesh_position_x"]["value"] = posX;
                     modelSettings_["overrides"]["mesh_position_x"]["default_value"] = posX;
                     modelSettings_["overrides"]["mesh_position_y"]["value"] = posY;
@@ -461,8 +461,9 @@ void UIManager::openModelPropertiesDialog()
                 glm::vec3 localCenter = mdl->center;
                 glm::vec3 worldCenter = glm::vec3(
                     modelManager_.GetTransform(activeModel_)->getMatrix() * glm::vec4(localCenter, 1.0f));
-                float bedX = worldCenter.x + renderer_->GetBedHalfWidth();
-                float bedY = worldCenter.y + renderer_->GetBedHalfDepth();
+                glm::vec3 plat = renderer_->GetPlatformOffset();
+                float bedX = worldCenter.x - plat.x;
+                float bedY = worldCenter.y - plat.y;
                 ImGui::Text("Slice Reference XY (mm): %.2f, %.2f", bedX, bedY);
                 }
             }
@@ -794,8 +795,9 @@ void UIManager::finalizeSlicing()
                     double posX = ov["mesh_position_x"]["value"].get<double>();
                     double posY = ov["mesh_position_y"]["value"].get<double>();
                     glm::vec3 c = gm->GetCenter();
-                    offset = glm::vec3(static_cast<float>(posX - c.x),
-                                       static_cast<float>(posY - c.y),
+                    glm::vec3 plat = renderer_ ? renderer_->GetPlatformOffset() : glm::vec3(0.0f);
+                    offset = glm::vec3(static_cast<float>(posX + plat.x - c.x),
+                                       static_cast<float>(posY + plat.y - c.y),
                                        0.f);
                     }
                 }


### PR DESCRIPTION
## Summary
- account for `platform_offset` in SceneRenderer
- allow grid and volume renderers to accept a translation offset
- convert model positions to machine coordinates when preparing settings
- offset G-code visualization based on platform offset

## Testing
- `cmake -B build -S .` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_685312c24d648321906715387333c814