### PR TITLE
Fix CuraEngine invocation with extruder definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,10 @@ target_compile_definitions(RendRipper PRIVATE
 		        PRIMITIVE_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/fdmprinter.def.json\"
 		        BASE_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_base.def.json\"
                         A1MINI_PRINTER_SETTINGS_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini.def.json\"
+                        A1MINI_EXTRUDER0_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini_extruder_0.def.json\"
+                        A1MINI_EXTRUDER1_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini_extruder_1.def.json\"
+                        A1MINI_EXTRUDER2_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini_extruder_2.def.json\"
+                        A1MINI_EXTRUDER3_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/printer_settings/bambulab_a1mini_extruder_3.def.json\"
                         GCODE_OUTPUT_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources/generated_gcode\"
                 MESHLIB_AVAILABLE
 )

--- a/src/ui/UIManagerHelpers.cpp
+++ b/src/ui/UIManagerHelpers.cpp
@@ -346,6 +346,7 @@ void UIManager::sliceActiveModel()
         std::string cmd = std::string(CURA_ENGINE_EXE) +
                           " slice -j " + std::string(PRIMITIVE_PRINTER_SETTINGS_FILE) + " -j " +
                           std::string(BASE_PRINTER_SETTINGS_FILE) + " -j " + std::string(A1MINI_PRINTER_SETTINGS_FILE) +
+                          " -j " + std::string(A1MINI_EXTRUDER0_FILE) +
                           " -j " + std::string(MODEL_SETTINGS_FILE) +
                           " -l \"" + pendingResizedPath_ + "\"" +
                           " -o \"" + pendingGcodePath_ + "\"";


### PR DESCRIPTION
## Summary
- define macros for BambuLab extruder profiles
- include extruder 0 profile when building the CuraEngine command

## Testing
- `python3 scripts/check_printer_config.py resources/printer_settings/bambulab_a1mini.def.json`

------
https://chatgpt.com/codex/tasks/task_e_685490b8a0d883218c279f5ed7b72063