### PR TITLE
Expose Cura slicer settings in UI

### DIFF
--- a/resources/model_settings/model_settings.json
+++ b/resources/model_settings/model_settings.json
@@ -1,0 +1,19 @@
+{
+  "overrides": {
+    "mesh_position_x": {"value": 90, "default_value": 90},
+    "mesh_position_y": {"value": 90, "default_value": 90},
+    "center_object": {"value": false, "default_value": false},
+    "material_bed_temperature": {"value": 60, "default_value": 60},
+    "material_print_temperature": {"value": 200, "default_value": 200},
+    "speed_print": {"value": 60, "default_value": 60},
+    "support_enable": {"value": false, "default_value": false},
+    "support_type": {"value": "buildplate", "default_value": "buildplate"},
+    "support_infill_rate": {"value": 15, "default_value": 15},
+    "support_structure": {"value": "normal", "default_value": "normal"},
+    "support_angle": {"value": 50, "default_value": 50},
+    "support_tree_angle": {"value": 60, "default_value": 60},
+    "support_pattern": {"value": "zigzag", "default_value": "zigzag"},
+    "infill_sparse_density": {"value": 20, "default_value": 20},
+    "infill_pattern": {"value": "grid", "default_value": "grid"}
+  }
+}

--- a/src/gcode/GCodeModel.cpp
+++ b/src/gcode/GCodeModel.cpp
@@ -23,7 +23,10 @@
 GCodeModel::GCodeModel(const std::string &gcodePath)
 {
     GCodeParser parser;
-    parser.Parse(gcodePath, layers_, layerZs_);
+    GCodeMeta meta;
+    parser.Parse(gcodePath, layers_, layerZs_, &meta);
+    filamentUsedMeters_ = meta.filament_used_m;
+    printTimeSeconds_ = meta.print_time_seconds;
     if (!layers_.empty())
         {
         computeBounds();

--- a/src/gcode/GCodeModel.h
+++ b/src/gcode/GCodeModel.h
@@ -60,6 +60,12 @@ public:
     /** @brief Center of all parsed vertices. */
     const glm::vec3 &GetCenter() const { return center_; }
 
+    /** @brief Filament used in meters. */
+    double GetFilamentUsedMeters() const { return filamentUsedMeters_; }
+
+    /** @brief Estimated print time in seconds. */
+    int GetPrintTimeSeconds() const { return printTimeSeconds_; }
+
 private:
     /**
      * @brief Recalculate center, radius and bounds across all layers.
@@ -92,6 +98,9 @@ private:
     std::vector<unsigned int> layerVBOs_;
 
     bool ready_{false};
+
+    double filamentUsedMeters_ = 0.0;
+    int printTimeSeconds_ = 0;
 
     // We do *not* keep one big “lineVertices_” vector anymore; it's now split per layer.
     // Temporary storage is used only during parsing.

--- a/src/gcode/GCodeParser.cpp
+++ b/src/gcode/GCodeParser.cpp
@@ -21,13 +21,20 @@ void GCodeParser::Parse
 (
     const std::string &path,
     std::vector<std::vector<GCodeColoredVertex> > &layers,
-    std::vector<float> &layerZs
+    std::vector<float> &layerZs,
+    GCodeMeta *meta
 ) const
 {
     std::ifstream in(path);
     if (!in.is_open())
         {
         throw std::runtime_error("Failed to open G-code file: " + path);
+        }
+
+    if (meta)
+        {
+        meta->print_time_seconds = 0;
+        meta->filament_used_m = 0.0;
         }
 
     std::string line;
@@ -50,6 +57,20 @@ void GCodeParser::Parse
         if (semiPos != std::string::npos)
             {
             comment = line.substr(semiPos + 1);
+            }
+
+        if (meta && !comment.empty())
+            {
+            if (comment.rfind("TIME:", 0) == 0)
+                {
+                try { meta->print_time_seconds = std::stoi(comment.substr(5)); } catch (...) {}
+                }
+            else if (comment.rfind("Filament used:", 0) == 0)
+                {
+                std::string v = comment.substr(14);
+                if (!v.empty() && v.back() == 'm') v.pop_back();
+                try { meta->filament_used_m = std::stod(v); } catch (...) {}
+                }
             }
 
         std::smatch m;

--- a/src/gcode/GCodeParser.h
+++ b/src/gcode/GCodeParser.h
@@ -15,6 +15,12 @@ struct GCodeColoredVertex
 /**
  * @brief Utility for parsing .gcode files into drawable layers.
  */
+struct GCodeMeta
+{
+    int print_time_seconds = 0;
+    double filament_used_m = 0.0;
+};
+
 class GCodeParser
 {
 public:
@@ -28,6 +34,7 @@ public:
     (
         const std::string &path,
         std::vector<std::vector<GCodeColoredVertex> > &layers,
-        std::vector<float> &layerZs
+        std::vector<float> &layerZs,
+        GCodeMeta *meta = nullptr
     ) const;
 };

--- a/src/ui/UIManagerHelpers.cpp
+++ b/src/ui/UIManagerHelpers.cpp
@@ -711,6 +711,8 @@ void UIManager::openModelPropertiesDialog()
             ImGui::Text("Z = %.2f mm (layer %d of %d)", layerHeights[(currentGCodeLayer_ < 0 ? 0 : currentGCodeLayer_)],
                         (currentGCodeLayer_ < 0 ? 0 : currentGCodeLayer_), layerCount - 1);
             ImGui::SliderInt("Layer", &currentGCodeLayer_, -1, layerCount - 1, currentGCodeLayer_ < 0 ? "All" : "%d");
+            ImGui::Text("Time: %.1f min", gcodeModel_->GetPrintTimeSeconds() / 60.0f);
+            ImGui::Text("Filament: %.2f m", gcodeModel_->GetFilamentUsedMeters());
             }
         else
             {


### PR DESCRIPTION
## Summary
- store print time and filament usage when parsing gcode
- surface this information in the slice preview UI
- add optional metadata struct for the gcode parser
- use new metadata in `GCodeModel`
- provide default model slicing settings for BambuLab A1 mini
- extend settings with additional support options

## Testing
- `cmake -S . -B build` *(fails: Failed to find wayland-scanner)*

------
https://chatgpt.com/codex/tasks/task_e_68580609daa88321b7c6a1b141aeb71f